### PR TITLE
Add global header and footer components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import "@/app/globals.css"
 import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
+import Header from "@/components/header"
+import Footer from "@/components/footer"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -15,7 +17,9 @@ export default function RootLayout({ children }) {
     <html lang="ja" suppressHydrationWarning>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+          <Header />
           {children}
+          <Footer />
         </ThemeProvider>
       </body>
     </html>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,3 @@
+export default function Footer() {
+  return <footer className="text-center p-4">© dekopon21020014</footer>
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link"
+
+export default function Header() {
+  return (
+    <header className="bg-gray-100 dark:bg-gray-900 p-4">
+      <div className="container mx-auto flex items-center justify-between">
+        <h1 className="text-xl font-bold">
+          <Link href="/">Lab Scheduling</Link>
+        </h1>
+        <nav className="space-x-4">
+          <Link href="/events">Events</Link>
+        </nav>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add Header and Footer components
- render Header and Footer around page content for consistent site chrome

## Testing
- `pnpm lint` *(fails: Next.js asks to configure ESLint)*
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68ae59516cbc832899093b354748bacf