### PR TITLE
feat: add social filter response option

### DIFF
--- a/app/events/[eventId]/components/constants.ts
+++ b/app/events/[eventId]/components/constants.ts
@@ -30,6 +30,7 @@ export type EventData = {
 // スケジュールの種類と対応する表示色など
 export const scheduleTypes = [
     { id: "available", label: "可能", color: "bg-green-100 text-green-800" },
+    { id: "social", label: "🐈", color: "bg-orange-100 text-orange-800" },
     { id: "not-yet", label: "未定", color: "bg-yellow-100 text-yellow-800" },
     { id: "class", label: "授業", color: "bg-red-100 text-red-800" },
     { id: "ta", label: "TA", color: "bg-purple-100 text-purple-800" },
@@ -107,6 +108,7 @@ export const onetimeTemplates = [
 
 export const scheduleTypeTamplate = [
     { id: "available", label: "可能", color: "bg-green-100 text-green-800", isAvailable: true },
+    { id: "social", label: "🐈", color: "bg-orange-100 text-orange-800", isAvailable: false },
     { id: "not-yet", label: "未定(△)", color: "bg-yellow-100 text-yellow-800", isAvailable: false },
     { id: "class", label: "授業", color: "bg-red-100 text-red-800", isAvailable: false },
     { id: "ta", label: "TA", color: "bg-purple-100 text-purple-800", isAvailable: false },


### PR DESCRIPTION
## Summary
- add "社会性フィルター" schedule type for participants who can attend but would rather not
- represent this schedule type with a 🐈 emoji

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae73f9df248328ac96c265611cd626