### PR TITLE
feat: preset available type

### DIFF
--- a/app/events/[eventId]/components/OneTimeInput.tsx
+++ b/app/events/[eventId]/components/OneTimeInput.tsx
@@ -45,7 +45,14 @@ export default function OneTimeInputTab({
 }: Props) {
   const [name, setName] = useState("")
   const [grade, setGrade] = useState("")
-  const [selections, setSelections] = useState<Record<string, string>>({})
+  const available = scheduleTypes.find((t) => t.isAvailable)
+  const initialSelections: Record<string, string> = {}
+  if (available) {
+    dateTimeOptions.forEach((dt) => {
+      initialSelections[dt] = available.id
+    })
+  }
+  const [selections, setSelections] = useState<Record<string, string>>(initialSelections)
   const [comments, setComments] = useState<Record<string, string>>({})
   const [showComments, setShowComments] = useState<Record<string, boolean>>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -133,7 +140,7 @@ export default function OneTimeInputTab({
     }
   }
   const clearResponses = () => {
-    setSelections({})
+    setSelections(initialSelections)
     setComments({})
   }
 

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -51,8 +51,9 @@ export default function ScheduleForm({
   setActiveTab,
 }: Props) {
   const isMobile = useMediaQuery("(max-width: 768px)")
+  const defaultTypeId = scheduleTypes.find((t) => t.isAvailable)?.id || ""
   const [selectedCells, setSelectedCells] = useState<{ [key: string]: boolean }>({})
-  const [bulkScheduleType, setBulkScheduleType] = useState<string>("")
+  const [bulkScheduleType, setBulkScheduleType] = useState<string>(defaultTypeId)
   const [selectionMode, setSelectionMode] = useState<"tap" | "drag">(isMobile ? "tap" : "drag")
   const [scheduleError, setScheduleError] = useState("")
   const [nameError, setNameError] = useState("")
@@ -72,13 +73,13 @@ export default function ScheduleForm({
       setCurrentGrade(p.grade || "")
       setCurrentSchedule({ ...p.schedule })
     } else {
-      setCurrentSchedule(createEmptySchedule(xAxis, yAxis))
+      setCurrentSchedule(createEmptySchedule(xAxis, yAxis, defaultTypeId))
     }
-  }, [editingIndex, participants, xAxis, yAxis])
+  }, [editingIndex, participants, xAxis, yAxis, defaultTypeId])
 
   useEffect(() => {
-    setBulkScheduleType(scheduleTypes[0]?.id || "")
-  },[scheduleTypes])
+    setBulkScheduleType(defaultTypeId)
+  },[defaultTypeId])
 
   const updateSchedule = (labelX: string, labelY: string, value: string) => {
     const key = `${labelX}-${labelY}`
@@ -158,9 +159,9 @@ export default function ScheduleForm({
       toast({ title: "完了", description: "スケジュールを登録しました" })
       setCurrentName("")
       setCurrentGrade("")
-      setCurrentSchedule(createEmptySchedule(xAxis, yAxis))
+      setCurrentSchedule(createEmptySchedule(xAxis, yAxis, defaultTypeId))
       setSelectedCells({})
-      setBulkScheduleType("")
+      setBulkScheduleType(defaultTypeId)
       setScheduleError("")
       setActiveTab("summary")
     } catch {

--- a/app/events/[eventId]/components/SchedulePage.tsx
+++ b/app/events/[eventId]/components/SchedulePage.tsx
@@ -35,6 +35,7 @@ type Props = {
 }
 
 export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
+  const defaultTypeId = scheduleTypes.find((t) => t.isAvailable)?.id || ''
   const [participants, setParticipants] = useState<Participant[]>([])
   const [availableOptions, setAvailableOptions] = useState<string[]>([])
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -43,7 +44,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
   const [currentGrade, setCurrentGrade] = useState('')
 
   const [currentSchedule, setCurrentSchedule] = useState<Schedule>(
-    () => createEmptySchedule(xAxis, yAxis)
+    () => createEmptySchedule(xAxis, yAxis, defaultTypeId)
   )
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
   const [filterGrades, setFilterGrades] = useState<string[]>([])
@@ -79,9 +80,9 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
       setCurrentGrade(p.grade || '')
       setCurrentSchedule({ ...p.schedule })
     } else {
-      setCurrentSchedule(createEmptySchedule(xAxis, yAxis))
+      setCurrentSchedule(createEmptySchedule(xAxis, yAxis, defaultTypeId))
     }
-  }, [editingIndex, participants, xAxis, yAxis])
+  }, [editingIndex, participants, xAxis, yAxis, defaultTypeId])
 
   const toggleGradeFilter = (g: string) => {
     setFilterGrades(prev => prev.includes(g) ? prev.filter(x=>x!==g) : [...prev, g])

--- a/app/events/[eventId]/components/utils.ts
+++ b/app/events/[eventId]/components/utils.ts
@@ -7,12 +7,13 @@ import type { Schedule } from './types'
  */
 export function createEmptySchedule(
   xAxis: string[],
-  yAxis: string[]
+  yAxis: string[],
+  defaultTypeId = ''
 ): Schedule {
   const schedule: Schedule = {}
   xAxis.forEach((labelX) => {
     yAxis.forEach((labelY) => {
-      schedule[`${labelX}-${labelY}`] = ''
+      schedule[`${labelX}-${labelY}`] = defaultTypeId
     })
   })
   return schedule


### PR DESCRIPTION
## Summary
- preset responder defaults to the first available schedule type
- restore selections to defaults when clearing responses

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8ca99cc08328a7cc53451f171b4d