### PR TITLE
feat: refresh home page with dark style

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="ja" suppressHydrationWarning>
       <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <Header />
           {children}
           <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -299,20 +299,15 @@ export default function HomePage() {
   }
 
   return (
-    <div className="container mx-auto py-10 px-4">
-      <h1 className="text-3xl font-bold mb-6">イベント管理アプリ</h1>
+    <div className="min-h-screen bg-gradient-to-b from-black to-gray-950 text-white">
+      <section className="py-24">
+        <div className="container mx-auto text-center space-y-4">
+          <h1 className="text-5xl font-bold tracking-tight">Lab Scheduling</h1>
+          <p className="text-lg text-gray-400">研究室の予定調整をスマートに</p>
+        </div>
+      </section>
 
-      <p className="mb-4 text-gray-700">
-        このアプリは、研究室ゼミや勉強会などの「日程調整」を簡単に行うためのツールです。
-      </p>
-
-      <ol className="list-decimal list-inside mb-8 text-gray-600">
-        <li>イベント名と説明を入力し、「イベントを作成」をクリック。</li>
-        <li>生成されたリンクを参加者に共有。</li>
-        <li>参加者は各自の空きコマを入力。</li>
-        <li>管理画面で全員の回答を集計し、最適な日程を確認。</li>
-      </ol>
-
+      <div className="container mx-auto py-10 px-4 bg-gray-900/50 rounded-xl">
       <form onSubmit={handleSubmit} className="max-w-3xl mx-auto space-y-6">
         <div className="grid md:grid-cols-2 gap-4">
           <div>
@@ -793,6 +788,7 @@ export default function HomePage() {
           イベントを作成
         </Button>
       </form>
+      </div>
     </div>
   )
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,3 +1,7 @@
 export default function Footer() {
-  return <footer className="text-center p-4">© dekopon21020014</footer>
+  return (
+    <footer className="bg-black border-t border-gray-800 text-gray-400 text-center py-6">
+      © {new Date().getFullYear()} Lab Scheduling
+    </footer>
+  )
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -10,17 +10,21 @@ export default function Header() {
     { href: "/events", label: "Events" },
   ]
   return (
-    <header className="bg-gray-100 dark:bg-gray-900 p-4">
-      <div className="container mx-auto flex items-center justify-between">
-        <h1 className="text-xl font-bold">
-          <Link href="/">Lab Scheduling</Link>
+    <header className="bg-black/80 backdrop-blur border-b border-gray-800">
+      <div className="container mx-auto flex items-center justify-between py-4">
+        <h1 className="text-xl font-semibold tracking-tight">
+          <Link href="/" className="text-white">
+            Lab Scheduling
+          </Link>
         </h1>
-        <nav className="space-x-4">
+        <nav className="space-x-6 text-sm">
           {navItems.map((item) => (
             <Link
               key={item.href}
               href={item.href}
-              className={pathname === item.href ? "font-semibold underline" : ""}
+              className={`text-gray-300 hover:text-white transition-colors ${
+                pathname === item.href ? "text-white underline" : ""
+              }`}
             >
               {item.label}
             </Link>


### PR DESCRIPTION
## Summary
- default to dark theme across the app
- add a black hero section and containerize the scheduler
- redesign header and footer with sleek dark styling

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch Inter from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9898820c83289c675e02aa0264ae