### PR TITLE
Fix builder tab list overflow on mobile

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -381,7 +381,7 @@ export default function HomePage() {
           <h2 className="text-lg font-medium mb-4">{eventType === "recurring" ? "グリッド設定" : "日時設定"}</h2>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="mb-4">
+            <TabsList className="mb-4 flex w-full overflow-x-auto justify-start md:justify-center">
               <TabsTrigger value="builder">{eventType === "recurring" ? "グリッドビルダー" : "日時リスト"}</TabsTrigger>
               <TabsTrigger value="scheduleTypes">予定タイプ</TabsTrigger>
               <TabsTrigger value="preview">プレビュー</TabsTrigger>


### PR DESCRIPTION
## Summary
- prevent builder tab list from overflowing on small screens by making the list flex and scrollable

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68afff30a74483288b7e88cf85f8bb45