### PR TITLE
feat: add color options for schedule types

### DIFF
--- a/app/events/[eventId]/components/constants.ts
+++ b/app/events/[eventId]/components/constants.ts
@@ -29,13 +29,13 @@ export type EventData = {
 
 // スケジュールの種類と対応する表示色など
 export const scheduleTypes = [
-    { id: "available", label: "可能", color: "bg-gray-100 text-gray-800" },
-    { id: "social", label: "🐈", color: "bg-gray-100 text-gray-800" },
-    { id: "not-yet", label: "未定", color: "bg-gray-100 text-gray-800" },
-    { id: "class", label: "授業", color: "bg-gray-100 text-gray-800" },
-    { id: "ta", label: "TA", color: "bg-gray-100 text-gray-800" },
-    { id: "unavailable", label: "不可", color: "bg-gray-100 text-gray-800" },
-    { id: "parttime", label: "バイト", color: "bg-gray-100 text-gray-800" },
+    { id: "available", label: "可能", color: "bg-green-200 text-green-800" },
+    { id: "social", label: "🐈", color: "bg-blue-200 text-blue-800" },
+    { id: "not-yet", label: "未定", color: "bg-yellow-200 text-yellow-800" },
+    { id: "class", label: "授業", color: "bg-purple-200 text-purple-800" },
+    { id: "ta", label: "TA", color: "bg-teal-200 text-teal-800" },
+    { id: "unavailable", label: "不可", color: "bg-red-200 text-red-800" },
+    { id: "parttime", label: "バイト", color: "bg-orange-200 text-orange-800" },
 ]
 
 // 曜日と時限の定義
@@ -69,6 +69,14 @@ export const colorPalettes = [
   { bg: "bg-gray-100", text: "text-gray-800", name: "薄灰" },
   { bg: "bg-gray-300", text: "text-gray-900", name: "灰" },
   { bg: "bg-gray-500", text: "text-white", name: "濃灰" },
+  { bg: "bg-red-200", text: "text-red-800", name: "赤" },
+  { bg: "bg-yellow-200", text: "text-yellow-800", name: "黄" },
+  { bg: "bg-green-200", text: "text-green-800", name: "緑" },
+  { bg: "bg-blue-200", text: "text-blue-800", name: "青" },
+  { bg: "bg-purple-200", text: "text-purple-800", name: "紫" },
+  { bg: "bg-pink-200", text: "text-pink-800", name: "桃" },
+  { bg: "bg-teal-200", text: "text-teal-800", name: "ティール" },
+  { bg: "bg-orange-200", text: "text-orange-800", name: "橙" },
 ]
 
 export const recurringTemplates = [
@@ -93,13 +101,13 @@ export const onetimeTemplates = [
 ]
 
 export const scheduleTypeTemplate = [
-    { id: "available", label: "可能", color: "bg-gray-100 text-gray-800", isAvailable: true },
-    { id: "social", label: "🐈", color: "bg-gray-100 text-gray-800", isAvailable: false },
-    { id: "not-yet", label: "未定(△)", color: "bg-gray-100 text-gray-800", isAvailable: false },
-    { id: "class", label: "授業", color: "bg-gray-100 text-gray-800", isAvailable: false },
-    { id: "ta", label: "TA", color: "bg-gray-100 text-gray-800", isAvailable: false },
-    { id: "unavailable", label: "不可", color: "bg-gray-100 text-gray-800", isAvailable: false },
-    { id: "parttime", label: "バイト", color: "bg-gray-100 text-gray-800", isAvailable: false },
+    { id: "available", label: "可能", color: "bg-green-200 text-green-800", isAvailable: true },
+    { id: "social", label: "🐈", color: "bg-blue-200 text-blue-800", isAvailable: false },
+    { id: "not-yet", label: "未定(△)", color: "bg-yellow-200 text-yellow-800", isAvailable: false },
+    { id: "class", label: "授業", color: "bg-purple-200 text-purple-800", isAvailable: false },
+    { id: "ta", label: "TA", color: "bg-teal-200 text-teal-800", isAvailable: false },
+    { id: "unavailable", label: "不可", color: "bg-red-200 text-red-800", isAvailable: false },
+    { id: "parttime", label: "バイト", color: "bg-orange-200 text-orange-800", isAvailable: false },
 ]
 
 export const xAxisTemplate = ["月", "火", "水", "木", "金"]


### PR DESCRIPTION
## Summary
- allow schedule types to use distinct tailwind color classes
- expand color palette with multiple vibrant options for schedule customization

## Testing
- `pnpm lint` *(fails: project prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b00b51b494832899b19548f7b5f227