### PR TITLE
Fix analytics schedule parsing and add dashboard link

### DIFF
--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -7,13 +7,14 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { toast } from "@/components/ui/use-toast"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Plus, Trash2, Save, X } from "lucide-react"
+import { Plus, Trash2, Save, X, BarChart3 } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import SchedulePage from "@/app/events/[eventId]/components/SchedulePage"
 import OneTimePage from "@/app/events/[eventId]/components/OneTimePage"
 import type { EventData, ScheduleType } from "@/app/events/[eventId]/components/constants"
 import { colorPalettes } from "@/app/events/[eventId]/components/constants"
+import Link from "next/link"
 
 export default function EventPage() {
   const { eventId } = useParams()
@@ -638,9 +639,17 @@ export default function EventPage() {
         <div className="space-y-2">
           <h1 className="text-2xl md:text-3xl font-bold">{data.name}</h1>
           <p className="text-gray-700">{data.description}</p>
-          <Button variant="outline" onClick={() => setEditMode(true)}>
-            編集
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => setEditMode(true)}>
+              編集
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/events/${eventId}/analytics`}>
+                <BarChart3 className="h-4 w-4 mr-2" />
+                統計
+              </Link>
+            </Button>
+          </div>
         </div>
       )}
 

--- a/app/events/[eventId]/analytics/page.tsx
+++ b/app/events/[eventId]/analytics/page.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useParams } from "next/navigation"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart"
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+} from "recharts"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import type {
+  ScheduleType,
+  Response,
+} from "@/app/events/[eventId]/components/constants"
+import { gradeOptions } from "@/app/events/[eventId]/components/constants"
+
+export default function AnalyticsPage() {
+  const { eventId } = useParams()
+  const [eventName, setEventName] = useState("読み込み中...")
+  const [scheduleTypes, setScheduleTypes] = useState<ScheduleType[]>([])
+  const [responses, setResponses] = useState<Response[]>([])
+
+  useEffect(() => {
+    if (!eventId) return
+    fetch(`/api/events/${eventId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setEventName(data.name || "")
+        setScheduleTypes(Array.isArray(data.scheduleTypes) ? data.scheduleTypes : [])
+        setResponses(
+          Array.isArray(data.participants)
+            ? data.participants.map((p: any) => ({
+                id: p.id,
+                name: p.name,
+                grade: p.grade,
+                // Firestore may store schedule as an object keyed by slot id
+                // or as an array. Normalize to an array to simplify later
+                // aggregation and avoid runtime errors when calling forEach.
+                schedule: Array.isArray(p.schedule)
+                  ? p.schedule
+                  : Object.values(p.schedule || {}),
+              }))
+            : [],
+        )
+      })
+  }, [eventId])
+
+  const scheduleCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    scheduleTypes.forEach((t) => {
+      counts[t.id] = 0
+    })
+    responses.forEach((r) => {
+      const scheduleEntries = Array.isArray(r.schedule)
+        ? r.schedule
+        : Object.values(r.schedule || {})
+      scheduleEntries.forEach((s) => {
+        counts[s.typeId] = (counts[s.typeId] || 0) + 1
+      })
+    })
+    return scheduleTypes.map((t) => ({ id: t.id, label: t.label, count: counts[t.id] || 0 }))
+  }, [scheduleTypes, responses])
+
+  const pieColors = [
+    "hsl(var(--chart-1))",
+    "hsl(var(--chart-2))",
+    "hsl(var(--chart-3))",
+    "hsl(var(--chart-4))",
+    "hsl(var(--chart-5))",
+  ]
+
+  const pieConfig = useMemo(() => {
+    const config: Record<string, { label: string; color: string }> = {}
+    scheduleCounts.forEach((sc, idx) => {
+      config[sc.id] = { label: sc.label, color: pieColors[idx % pieColors.length] }
+    })
+    return config
+  }, [scheduleCounts])
+
+  const pieData = useMemo(
+    () =>
+      scheduleCounts.map((sc) => ({
+        scheduleType: sc.id,
+        count: sc.count,
+      })),
+    [scheduleCounts],
+  )
+
+  const gradeCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    responses.forEach((r) => {
+      const g = r.grade || "Others"
+      counts[g] = (counts[g] || 0) + 1
+    })
+    return counts
+  }, [responses])
+
+  const gradeData = useMemo(
+    () =>
+      gradeOptions.map((g) => ({
+        grade: g,
+        count: gradeCounts[g] || 0,
+      })),
+    [gradeCounts],
+  )
+
+  const barConfig = { count: { label: "人数", color: "hsl(var(--chart-1))" } }
+
+  return (
+    <div className="space-y-6 p-4">
+      <h1 className="text-2xl font-bold">{eventName}の統計</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>スケジュールタイプ別の集計</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={pieConfig} className="h-[300px] w-full">
+            <PieChart>
+              <ChartTooltip content={<ChartTooltipContent nameKey="scheduleType" />} />
+              <Pie
+                data={pieData}
+                dataKey="count"
+                nameKey="scheduleType"
+                innerRadius={60}
+                stroke="none"
+              >
+                {pieData.map((item) => (
+                  <Cell
+                    key={item.scheduleType}
+                    fill={`var(--color-${item.scheduleType})`}
+                  />
+                ))}
+              </Pie>
+              <ChartLegend content={<ChartLegendContent nameKey="scheduleType" />} />
+            </PieChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>学年別参加人数</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={barConfig} className="h-[300px] w-full">
+            <BarChart data={gradeData}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="grade"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={10}
+              />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey="count" fill="var(--color-count)" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/app/events/[eventId]/components/EventHeader.tsx
+++ b/app/events/[eventId]/components/EventHeader.tsx
@@ -4,7 +4,8 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { Settings, Calendar, CalendarDays, Share2 } from "lucide-react"
+import Link from "next/link"
+import { Settings, Calendar, CalendarDays, Share2, BarChart3 } from "lucide-react"
 import { toast } from "@/components/ui/use-toast"
 import EventSettings from "./EventSettings"
 import type { ScheduleType } from "./constants"
@@ -81,6 +82,13 @@ export default function EventHeader({
             <Button variant="outline" size="sm" onClick={copyEventUrl}>
               <Share2 className="h-4 w-4 mr-1" />
               共有
+            </Button>
+
+            <Button variant="outline" size="sm" asChild>
+              <Link href={`/events/${eventId}/analytics`}>
+                <BarChart3 className="h-4 w-4 mr-1" />
+                統計
+              </Link>
             </Button>
 
             <Dialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>


### PR DESCRIPTION
## Summary
- normalize participant schedules when loading analytics to avoid iteration errors
- add an "統計" button linking to analytics dashboard on event page

## Testing
- `pnpm lint` *(fails: project prompts for ESLint configuration)*
- `pnpm build` *(fails: Service account object missing `project_id`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b26d0a248328934d9bdfff15cf94