### PR TITLE
feat: customize affiliations and allow user-defined options

### DIFF
--- a/app/api/events/[eventId]/participants/[participantId]/route.ts
+++ b/app/api/events/[eventId]/participants/[participantId]/route.ts
@@ -13,7 +13,7 @@ export async function PUT(
     return NextResponse.json({ error: '名前が必要です' }, { status: 400 })
   }  
   if (!grade || typeof grade !== 'string') {
-    return NextResponse.json({ error: '学年が必要です' }, { status: 400 })
+    return NextResponse.json({ error: '所属/役職が必要です' }, { status: 400 })
   }
   if (!schedule || typeof schedule !== 'object') {
     return NextResponse.json({ error: 'スケジュールが必要です' }, { status: 400 })
@@ -31,6 +31,10 @@ export async function PUT(
         schedule,
         updatedAt: FieldValue.serverTimestamp(),
       })
+
+    await db.collection('events').doc(eventId).update({
+      gradeOptions: FieldValue.arrayUnion(grade),
+    })
     return NextResponse.json({ message: '更新しました' })
   } catch (err) {
     console.error('更新エラー:', err)

--- a/app/api/events/[eventId]/participants/route.ts
+++ b/app/api/events/[eventId]/participants/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "名前が必要です" }, { status: 400 })
   }
   if (!grade || typeof grade !== "string") {
-    return NextResponse.json({ error: "学年が必要です" }, { status: 400 })
+    return NextResponse.json({ error: "所属/役職が必要です" }, { status: 400 })
   }
   if (!schedule || typeof schedule !== "object") {
     return NextResponse.json({ error: "スケジュールが必要です" }, { status: 400 })
@@ -47,6 +47,10 @@ export async function POST(req: NextRequest) {
       grade,
       schedule,
       createdAt: FieldValue.serverTimestamp(),
+    })
+
+    await db.collection("events").doc(eventId).update({
+      gradeOptions: FieldValue.arrayUnion(grade),
     })
 
     return NextResponse.json({ message: "保存しました", id: docRef.id })

--- a/app/api/events/[eventId]/route.ts
+++ b/app/api/events/[eventId]/route.ts
@@ -1,6 +1,7 @@
 // app/api/events/[eventId]/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/firebase"
+import { defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
 
 interface ScheduleType {
   id: string
@@ -64,6 +65,7 @@ export async function GET(
     description: data.description,
     eventType,
     scheduleTypes,
+    gradeOptions: Array.isArray(data.gradeOptions) ? data.gradeOptions : defaultGradeOptions,
     ...(eventType === "recurring"
       ? { xAxis, yAxis }
       : { dateTimeOptions }),
@@ -85,6 +87,7 @@ export async function PUT(
     xAxis,
     yAxis,
     dateTimeOptions,
+    gradeOptions,
   } = json
 
   // 基本バリデーション
@@ -122,6 +125,13 @@ export async function PUT(
       { error: "scheduleTypes は正しい形式で指定してください" },
       { status: 400 }
     )
+  }
+
+  if (
+    !Array.isArray(gradeOptions) ||
+    !gradeOptions.every((v: any) => typeof v === "string")
+  ) {
+    gradeOptions = defaultGradeOptions
   }
 
   // イベントタイプ別の検証
@@ -163,6 +173,7 @@ export async function PUT(
     description: description || "",
     eventType,
     scheduleTypes,
+    gradeOptions,
     updatedAt: new Date(),
   }
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,6 +1,7 @@
 // app/api/events/route.ts
 import { NextResponse, type NextRequest } from "next/server"
 import { db } from "@/lib/firebase"
+import { defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
 
 export async function POST(req: NextRequest) {
   const json = await req.json()
@@ -12,6 +13,7 @@ export async function POST(req: NextRequest) {
     yAxis,
     dateTimeOptions,
     scheduleTypes,
+    gradeOptions,
   } = json
 
   // --- 基本項目チェック ---
@@ -84,6 +86,11 @@ export async function POST(req: NextRequest) {
     )
   }
 
+  const grades =
+    Array.isArray(gradeOptions) && gradeOptions.every((v: any) => typeof v === "string")
+      ? gradeOptions
+      : defaultGradeOptions
+
   // --- Firestore に保存 ---
   try {
     const payload: any = {
@@ -91,6 +98,7 @@ export async function POST(req: NextRequest) {
       description: description || "",
       eventType,
       scheduleTypes,
+      gradeOptions: grades,
       createdAt: new Date(),
     }
     if (eventType === "recurring") {

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -23,6 +23,7 @@ import {
   CalendarDays,
   Clock,
   FileText,
+  UserPlus,
 } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
@@ -34,7 +35,8 @@ import {
   onetimeTemplates,
   scheduleTypeTemplate,
   xAxisTemplate,
-  yAxisTemplate
+  yAxisTemplate,
+  defaultGradeOptions
 } from "../events/[eventId]/components/constants"
 import type { ScheduleType } from "../events/[eventId]/components/constants"
 
@@ -50,6 +52,9 @@ export default function HomePage() {
   // 単発イベント用の軸（日時の組み合わせ）
   const [dateTimeOptions, setDateTimeOptions] = useState(["5/1 19:00", "5/2 19:00", "5/3 20:00"])
 
+  // 所属/役職の選択肢
+  const [gradeOptions, setGradeOptions] = useState<string[]>(defaultGradeOptions)
+
   const [activeTab, setActiveTab] = useState("builder")
   const router = useRouter()
 
@@ -60,6 +65,7 @@ export default function HomePage() {
   const yAxisRefs = useRef<HTMLInputElement[]>([])
   const dateTimeRefs = useRef<HTMLInputElement[]>([])
   const typeLabelRefs = useRef<HTMLInputElement[]>([])
+  const gradeOptionRefs = useRef<HTMLInputElement[]>([])
 
   // X軸の項目を追加
   const addXItem = () => {
@@ -119,6 +125,33 @@ export default function HomePage() {
     const newOptions = [...dateTimeOptions]
     newOptions.splice(index, 1)
     setDateTimeOptions(newOptions)
+  }
+
+  // 所属/役職の項目を追加
+  const addGradeOption = () => {
+    setGradeOptions((prev) => {
+      const newOptions = [...prev, `選択肢${prev.length + 1}`]
+      requestAnimationFrame(() => {
+        const newIndex = newOptions.length - 1
+        gradeOptionRefs.current[newIndex]?.focus()
+      })
+      return newOptions
+    })
+  }
+
+  // 所属/役職の項目を削除
+  const removeGradeOption = (index: number) => {
+    if (gradeOptions.length <= 1) return
+    const newOpts = [...gradeOptions]
+    newOpts.splice(index, 1)
+    setGradeOptions(newOpts)
+  }
+
+  // 所属/役職の項目を更新
+  const updateGradeOption = (index: number, value: string) => {
+    const newOpts = [...gradeOptions]
+    newOpts[index] = value
+    setGradeOptions(newOpts)
   }
 
   // X軸の項目を更新
@@ -273,6 +306,7 @@ export default function HomePage() {
       const cleanedXAxis         = removeEmptyStrings(xAxis)
       const cleanedYAxis         = removeEmptyStrings(yAxis)
       const cleanedDateTimes     = removeEmptyStrings(dateTimeOptions)
+      const cleanedGrades        = removeEmptyStrings(gradeOptions)
 
       // イベントタイプに応じたデータを準備
       const eventData = {
@@ -280,6 +314,7 @@ export default function HomePage() {
         description: eventDesc,
         eventType,
         scheduleTypes: cleanedScheduleTypes,
+        gradeOptions: cleanedGrades,
         xAxis: eventType === "recurring" ? cleanedXAxis : undefined,
         yAxis: eventType === "recurring" ? cleanedYAxis : undefined,
         dateTimeOptions: eventType === "onetime" ? cleanedDateTimes : undefined,
@@ -402,6 +437,41 @@ export default function HomePage() {
               {eventType === "recurring"
                 ? "定期的なミーティングや授業など、曜日×時間のグリッド形式で調整します。"
                 : "単発のイベントや会議など、特定の日時のリストから選択して調整します。"}
+            </div>
+          </CardContent>
+        </Card>
+        {/* 所属/役職設定 */}
+        <Card className="bg-white dark:bg-gray-800 shadow-sm border">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-lg font-medium flex items-center gap-2">
+              <UserPlus className="h-5 w-5" />
+              所属/役職の選択肢
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {gradeOptions.map((opt, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <Input
+                    ref={(el) => (gradeOptionRefs.current[i] = el)}
+                    value={opt}
+                    onChange={(e) => updateGradeOption(i, e.target.value)}
+                    className="flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => removeGradeOption(i)}
+                    disabled={gradeOptions.length <= 1}
+                  >
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </div>
+              ))}
+              <Button type="button" variant="outline" size="sm" onClick={addGradeOption} className="mt-2">
+                <Plus className="h-4 w-4 mr-1" />追加
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -28,6 +28,7 @@ export default function EventPage() {
     dateTimeOptions: [],
     scheduleTypes: [],
     existingResponses: [],
+    gradeOptions: [],
   })
 
   // 編集用の状態
@@ -78,6 +79,7 @@ export default function EventPage() {
                 schedule: p.schedule,
               }))
             : [],
+          gradeOptions: Array.isArray(resData.gradeOptions) ? resData.gradeOptions : [],
         })
         setName(resData.name)
         setDescription(resData.description ?? "")
@@ -657,13 +659,19 @@ export default function EventPage() {
       {!editMode && (
         <div className="mt-6">
           {data.eventType === "recurring" ? (
-            <SchedulePage xAxis={data.xAxis} yAxis={data.yAxis} scheduleTypes={data.scheduleTypes} />
+            <SchedulePage
+              xAxis={data.xAxis}
+              yAxis={data.yAxis}
+              scheduleTypes={data.scheduleTypes}
+              gradeOptions={data.gradeOptions}
+            />
           ) : (
             <OneTimePage
               eventId={eventId ? String(eventId) : ""}
               dateTimeOptions={data.dateTimeOptions}
               scheduleTypes={data.scheduleTypes}
               responses={data.existingResponses}
+              gradeOptions={data.gradeOptions}
             />
           )}
         </div>

--- a/app/events/[eventId]/analytics/page.tsx
+++ b/app/events/[eventId]/analytics/page.tsx
@@ -20,7 +20,6 @@ import {
 } from "recharts"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import type { ScheduleType } from "@/app/events/[eventId]/components/constants"
-import { gradeOptions } from "@/app/events/[eventId]/components/constants"
 
 type AnalyticsResponse = {
   id: string
@@ -34,6 +33,7 @@ export default function AnalyticsPage() {
   const [eventName, setEventName] = useState("読み込み中...")
   const [scheduleTypes, setScheduleTypes] = useState<ScheduleType[]>([])
   const [responses, setResponses] = useState<AnalyticsResponse[]>([])
+  const [gradeOptions, setGradeOptions] = useState<string[]>([])
 
   useEffect(() => {
     if (!eventId) return
@@ -42,6 +42,7 @@ export default function AnalyticsPage() {
       .then((data) => {
         setEventName(data.name || "")
         setScheduleTypes(Array.isArray(data.scheduleTypes) ? data.scheduleTypes : [])
+        setGradeOptions(Array.isArray(data.gradeOptions) ? data.gradeOptions : [])
         setResponses(
           Array.isArray(data.participants)
             ? data.participants.map((p: any) => ({
@@ -116,7 +117,7 @@ export default function AnalyticsPage() {
         grade: g,
         count: gradeCounts[g] || 0,
       })),
-    [gradeCounts],
+    [gradeCounts, gradeOptions],
   )
 
   const barConfig = { count: { label: "人数", color: "hsl(var(--chart-1))" } }
@@ -155,7 +156,7 @@ export default function AnalyticsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>学年別参加人数</CardTitle>
+          <CardTitle>所属/役職別参加人数</CardTitle>
         </CardHeader>
         <CardContent>
           <ChartContainer config={barConfig} className="h-[300px] w-full">

--- a/app/events/[eventId]/components/OneTimeInput.tsx
+++ b/app/events/[eventId]/components/OneTimeInput.tsx
@@ -10,7 +10,7 @@ import {
   X,
   GraduationCap,
 } from "lucide-react"
-import { type ScheduleType, type Response, gradeOptions } from "./constants"
+import { type ScheduleType, type Response } from "./constants"
 import { toast } from "@/components/ui/use-toast"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -33,6 +33,8 @@ type Props = {
   existingResponses: Response[]
   setExistingResponses: React.Dispatch<React.SetStateAction<Response[]>>
   setActiveTab: (tab: string) => void
+  gradeOptions: string[]
+  setGradeOptions: React.Dispatch<React.SetStateAction<string[]>>
 }
 
 export default function OneTimeInputTab({
@@ -42,6 +44,8 @@ export default function OneTimeInputTab({
   existingResponses = [],
   setExistingResponses,
   setActiveTab,
+  gradeOptions,
+  setGradeOptions,
 }: Props) {
   const [name, setName] = useState("")
   const [grade, setGrade] = useState("")
@@ -161,7 +165,7 @@ export default function OneTimeInputTab({
           await handleSubmit()
         }}
       >
-        {/* 名前と学年 */}
+        {/* 名前と所属/役職 */}
         <Card className="mb-4">
           <CardContent className="pt-4 pb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
@@ -180,11 +184,27 @@ export default function OneTimeInputTab({
             <div>
               <Label htmlFor="participant-grade" className="text-sm font-medium mb-1 block">
                 <GraduationCap className="h-4 w-4 inline-block mr-1" />
-                学年
+                所属/役職
               </Label>
-              <Select value={grade} onValueChange={(v) => setGrade(v)}>
+              <Select
+                value={grade}
+                onValueChange={(v) => {
+                  if (v === "__add__") {
+                    const newGrade = prompt("所属/役職を入力してください")
+                    if (newGrade) {
+                      const trimmed = newGrade.trim()
+                      if (trimmed && !gradeOptions.includes(trimmed)) {
+                        setGradeOptions([...gradeOptions, trimmed])
+                      }
+                      setGrade(trimmed)
+                    }
+                    return
+                  }
+                  setGrade(v)
+                }}
+              >
                 <SelectTrigger id="participant-grade">
-                  <SelectValue placeholder="学年を選択してください" />
+                  <SelectValue placeholder="所属/役職を選択してください" />
                 </SelectTrigger>
                 <SelectContent>
                   {gradeOptions.map((opt) => (
@@ -192,6 +212,7 @@ export default function OneTimeInputTab({
                       {opt}
                     </SelectItem>
                   ))}
+                  <SelectItem value="__add__">追加</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/app/events/[eventId]/components/OneTimePage.tsx
+++ b/app/events/[eventId]/components/OneTimePage.tsx
@@ -7,7 +7,6 @@ import {
   Users, PenSquare, Edit, Trash2, AlertTriangle,
 } from "lucide-react"
 import type { ScheduleType, Response } from "./constants"
-import { gradeOptions } from "./constants"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -35,11 +34,13 @@ type Props = {
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   responses?: Response[]
+  gradeOptions: string[]
 }
 
-export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, responses = [] }: Props) {  
+export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, responses = [], gradeOptions }: Props) {
   const [activeTab, setActiveTab] = useState("input")
-  const form = useParticipantForm(eventId, dateTimeOptions, scheduleTypes, responses, setActiveTab)
+  const [gradeOptionsState, setGradeOptionsState] = useState<string[]>(gradeOptions)
+  const form = useParticipantForm(eventId, dateTimeOptions, scheduleTypes, responses, setActiveTab, gradeOptionsState)
   const isMobile = useMediaQuery("(max-width: 768px)")      
 
   // 最適な日時を取得
@@ -71,6 +72,8 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
             existingResponses={form.existingResponses}
             setExistingResponses={form.setExistingResponses}
             setActiveTab={setActiveTab}
+            gradeOptions={gradeOptionsState}
+            setGradeOptions={setGradeOptionsState}
         />
 
         {/* 回答状況タブ */}
@@ -79,6 +82,7 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
             scheduleTypes={scheduleTypes}
             responses={form.existingResponses}
             form={form}
+            gradeOptions={gradeOptionsState}
         />
 
         {/* 集計結果タブ */}
@@ -86,6 +90,7 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
             dateTimeOptions={dateTimeOptions}
             scheduleTypes={scheduleTypes}
             existingResponses={form.existingResponses}
+            gradeOptions={gradeOptionsState}
         />
       </Tabs>
 
@@ -114,7 +119,7 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
 
           {form.editingResponse && (
             <div className="space-y-4 py-2">
-              {/* 名前と学年入力セクション */}
+              {/* 名前と所属/役職入力セクション */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <Label htmlFor="edit-name" className="text-sm font-medium mb-1 block">
@@ -132,18 +137,35 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
                 <div>
                   <Label htmlFor="edit-grade" className="text-sm font-medium mb-1 block">
                     <GraduationCap className="h-4 w-4 inline-block mr-1" />
-                    学年
+                    所属/役職
                   </Label>
-                  <Select value={form.editGrade} onValueChange={(value) => form.setEditGrade(value)}>
+                  <Select
+                    value={form.editGrade}
+                    onValueChange={(value) => {
+                      if (value === "__add__") {
+                        const newGrade = prompt("所属/役職を入力してください")
+                        if (newGrade) {
+                          const trimmed = newGrade.trim()
+                          if (trimmed && !gradeOptionsState.includes(trimmed)) {
+                            setGradeOptionsState([...gradeOptionsState, trimmed])
+                          }
+                          form.setEditGrade(trimmed)
+                        }
+                        return
+                      }
+                      form.setEditGrade(value)
+                    }}
+                  >
                     <SelectTrigger id="edit-grade">
-                      <SelectValue placeholder="学年を選択してください" />
+                      <SelectValue placeholder="所属/役職を選択してください" />
                     </SelectTrigger>
                     <SelectContent>
-                      {gradeOptions.map((option) => (
+                      {gradeOptionsState.map((option) => (
                         <SelectItem key={option} value={option}>
                           {option}
                         </SelectItem>
                       ))}
+                      <SelectItem value="__add__">追加</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -10,7 +10,6 @@ import {
   Pencil,
 } from "lucide-react"
 import type { ScheduleType, Response } from "./constants"
-import { gradeOptions } from "./constants"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent  } from "@/components/ui/card"
@@ -27,6 +26,7 @@ type Props = {
   scheduleTypes: ScheduleType[]
   responses?: Response[]
   form: ParticipantFormHook
+  gradeOptions: string[]
 }
 
 export default function OneTimeResponsesTab({
@@ -34,6 +34,7 @@ export default function OneTimeResponsesTab({
   scheduleTypes,
   responses = [],
   form,
+  gradeOptions,
 }: Props) {
   // 
   const getResponseIcon = (response: Response, dateTime: string) => {
@@ -100,7 +101,7 @@ export default function OneTimeResponsesTab({
               <div className="relative w-full md:w-40">
                 <Search className="absolute left-2 top-2 h-3 w-3 text-gray-400" />
                 <Input
-                  placeholder="名前 or 学年で検索..."
+                  placeholder="名前 or 所属/役職で検索..."
                   value={form.searchQuery}
                   onChange={(e) => form.setSearchQuery(e.target.value)}
                   className="pl-7 h-8 text-xs"
@@ -122,7 +123,7 @@ export default function OneTimeResponsesTab({
                   className="h-8 text-xs"
                   onClick={() => form.handleSort("grade")}
                 >
-                  学年{form.sortColumn === "grade" && (form.sortDirection === "asc" ? "↑" : "↓")}
+                  所属/役職{form.sortColumn === "grade" && (form.sortDirection === "asc" ? "↑" : "↓")}
                 </Button>
                 <Button
                   variant={form.sortColumn === "availability" ? "default" : "outline"}
@@ -191,7 +192,7 @@ export default function OneTimeResponsesTab({
                         </SelectContent>
                       </Select>
                     </div>
-                    {/* 学年 */}
+                    {/* 所属/役職 */}
                     <div className="space-y-2">
                       <div className="grid grid-cols-2 gap-2">
                         {gradeOptions.map((g) => (

--- a/app/events/[eventId]/components/OneTimeSummary.tsx
+++ b/app/events/[eventId]/components/OneTimeSummary.tsx
@@ -1,25 +1,30 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useState, useMemo } from "react"
 import { TabsContent } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar, GraduationCap, Clock, PieChart } from "lucide-react"
 import type { ScheduleType, Response } from "./constants"
-import { gradeOrder } from "./constants"
 
 type Props = {
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
+  gradeOptions: string[]
 }
 
 export default function OneTimeSummaryTab({
   dateTimeOptions,
   scheduleTypes,
   existingResponses,
+  gradeOptions,
 }: Props) {
   const [summaryView, setSummaryView] = useState<"dates" | "grades">("dates")
+
+  const gradeOrder = useMemo(() => {
+    return gradeOptions.reduce((acc, g, i) => ({ ...acc, [g]: i }), {} as Record<string, number>)
+  }, [gradeOptions])
 
   // 指定日時の「参加可能」人数
   const getAvailableCount = (dateTime: string) =>
@@ -42,7 +47,7 @@ export default function OneTimeSummaryTab({
   const getResponseCountByType = (dateTime: string, typeId: string) =>
     getRespondentsByType(dateTime, typeId).length
 
-  // 指定学年・指定日時の「参加可能」人数
+  // 指定所属/役職・指定日時の「参加可能」人数
   const getAvailableCountByGradeAndDateTime = (grade: string, dateTime: string) =>
     existingResponses.filter((response) => {
       if (response.grade !== grade) return false
@@ -52,7 +57,7 @@ export default function OneTimeSummaryTab({
       return type?.isAvailable
     }).length
 
-  // 指定学年の回答タイプ分布
+  // 指定所属/役職の回答タイプ分布
   const getResponseTypeDistributionByGrade = (grade: string) => {
     const dist: Record<string, number> = {}
     scheduleTypes.forEach((t) => (dist[t.id] = 0))
@@ -107,7 +112,7 @@ export default function OneTimeSummaryTab({
                 onClick={() => setSummaryView("grades")}
               >
                 <GraduationCap className="h-4 w-4 mr-1" />
-                学年別
+                所属/役職別
               </button>
             </div>
           </div>
@@ -245,13 +250,13 @@ export default function OneTimeSummaryTab({
               </CardContent>
             </Card>
           ) : (
-            /* 学年別の集計表 */
+            /* 所属/役職別の集計表 */
             <div className="space-y-4">
               <Card>
                 <CardHeader className="pb-2">
                   <CardTitle className="text-base font-medium flex items-center">
                     <GraduationCap className="h-4 w-4 mr-2" />
-                    学年別の参加状況
+                    所属/役職別の参加状況
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="p-0">
@@ -260,7 +265,7 @@ export default function OneTimeSummaryTab({
                       <thead>
                         <tr className="bg-gray-50 border-b">
                           <th className="text-left py-2 px-3 font-medium">
-                            学年
+                            所属/役職
                           </th>
                           <th className="py-2 px-2 text-center font-medium">
                             回答者数
@@ -294,8 +299,8 @@ export default function OneTimeSummaryTab({
                         )
                           .sort(
                             ([a], [b]) =>
-                              (gradeOrder[a as keyof typeof gradeOrder] || 999) -
-                              (gradeOrder[b as keyof typeof gradeOrder] || 999)
+                              (gradeOrder[a] ?? 999) -
+                              (gradeOrder[b] ?? 999)
                           )
                           .map(([g, names]) => (
                             <tr key={g} className="hover:bg-gray-50">
@@ -342,7 +347,7 @@ export default function OneTimeSummaryTab({
                 <CardHeader className="pb-2">
                   <CardTitle className="text-base font-medium flex items-center">
                     <PieChart className="h-4 w-4 mr-2" />
-                    学年別の詳細情報
+                    所属/役職別の詳細情報
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
@@ -360,8 +365,8 @@ export default function OneTimeSummaryTab({
                     )
                       .sort(
                         ([a], [b]) =>
-                          (gradeOrder[a as keyof typeof gradeOrder] || 999) -
-                          (gradeOrder[b as keyof typeof gradeOrder] || 999)
+                          (gradeOrder[a] ?? 999) -
+                          (gradeOrder[b] ?? 999)
                       )
                       .map(([g, names]) => {
                         const dist = getResponseTypeDistributionByGrade(g)

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -35,6 +35,7 @@ type Props = {
   xAxis: string[]
   yAxis: string[]
   availableOptions: string[]
+  gradeOptions: string[]
 }
 
 export default function ParticipantList({
@@ -48,12 +49,13 @@ export default function ParticipantList({
   xAxis,
   yAxis,
   availableOptions,
+  gradeOptions,
 }: Props) {
   const isMobile = useMediaQuery('(max-width: 768px)')
   const { eventId } = useParams()
 
-  // 学年フィルタ／ソート／ビュー切り替え
-  const gradeOrder = ['Teacher', 'Dr', 'M2', 'M1', 'B4', 'B3', 'B2', 'B1', 'Others']
+  // 所属/役職フィルタ／ソート／ビュー切り替え
+  const gradeOrder = gradeOptions
   const [filterGrade, setFilterGrade] = useState<string>('All')
   const [sortAscending, setSortAscending] = useState<boolean>(true)
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid')
@@ -127,13 +129,13 @@ export default function ParticipantList({
       {/* ── フィルタ／ソート／ビュー切替 ── */}
       <div className="flex flex-wrap items-center justify-between mb-4 gap-4">
         <div className="flex items-center gap-2">
-          <Label htmlFor="filter-grade">学年フィルタ</Label>
+          <Label htmlFor="filter-grade">所属/役職フィルタ</Label>
           <Select value={filterGrade} onValueChange={setFilterGrade}>
             <SelectTrigger id="filter-grade" className="w-36">
-              <SelectValue placeholder="全学年" />
+              <SelectValue placeholder="全て" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="All">全学年</SelectItem>
+              <SelectItem value="All">全て</SelectItem>
               {gradeOrder.map((g) => (
                 <SelectItem key={g} value={g}>
                   {g}
@@ -149,7 +151,7 @@ export default function ParticipantList({
             size="sm"
             onClick={() => setSortAscending((p) => !p)}
           >
-            {sortAscending ? '学年↑' : '学年↓'}
+            {sortAscending ? '所属/役職↑' : '所属/役職↓'}
           </Button>
 
           <Button

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label"
 import { MousePointer, Smartphone, Check } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
-import { gradeOptions, type ScheduleType } from "@/app/events/[eventId]/components/constants"
+import { type ScheduleType } from "@/app/events/[eventId]/components/constants"
 import type { Schedule, Participant } from "./types"
 import { createEmptySchedule } from "./utils"
 import { useMediaQuery } from "@/hooks/use-mobile"
@@ -21,6 +21,7 @@ type Props = {
   xAxis: string[]
   yAxis: string[]
   scheduleTypes: ScheduleType[]
+  gradeOptions: string[]
   currentName: string
   setCurrentName: Dispatch<SetStateAction<string>>
   currentGrade: string
@@ -38,6 +39,7 @@ export default function ScheduleForm({
   xAxis,
   yAxis,
   scheduleTypes,
+  gradeOptions,
   currentName,
   setCurrentName,
   currentGrade,
@@ -58,6 +60,7 @@ export default function ScheduleForm({
   const [scheduleError, setScheduleError] = useState("")
   const [nameError, setNameError] = useState("")
   const [gradeError, setGradeError] = useState("")
+  const [gradeOpts, setGradeOpts] = useState<string[]>(gradeOptions)
   const { eventId } = useParams()
 
   const tableRef = useRef<HTMLDivElement>(null)
@@ -109,7 +112,7 @@ export default function ScheduleForm({
     }
     setNameError("")
     if (!currentGrade) {
-      const message = "学年を選択してください"
+      const message = "所属/役職を選択してください"
       setGradeError(message)
       toast({ title: "エラー", description: message, variant: "destructive" })
       return
@@ -184,7 +187,7 @@ export default function ScheduleForm({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {/* 名前・学年入力 */}
+        {/* 名前・所属/役職入力 */}
         <div className="mb-4 grid grid-cols-2 gap-4">
           <div>
             <Label htmlFor="name">名前</Label>
@@ -200,23 +203,35 @@ export default function ScheduleForm({
             {nameError && <p className="mt-2 text-sm text-red-500">{nameError}</p>}
           </div>
           <div>
-            <Label htmlFor="grade-select">学年</Label>
+            <Label htmlFor="grade-select">所属/役職</Label>
             <Select
               value={currentGrade}
               onValueChange={(v) => {
+                if (v === "__add__") {
+                  const newGrade = prompt("所属/役職を入力してください")
+                  if (newGrade) {
+                    const trimmed = newGrade.trim()
+                    if (trimmed && !gradeOpts.includes(trimmed)) {
+                      setGradeOpts([...gradeOpts, trimmed])
+                    }
+                    setCurrentGrade(trimmed)
+                  }
+                  return
+                }
                 setCurrentGrade(v)
                 setGradeError("")
               }}
             >
               <SelectTrigger id="grade-select" className="w-full">
-                <SelectValue placeholder="学年を選択" />
+                <SelectValue placeholder="所属/役職を選択" />
               </SelectTrigger>
               <SelectContent>
-                {gradeOptions.map((g) => (
+                {gradeOpts.map((g) => (
                   <SelectItem key={g} value={g}>
                     {g}
                   </SelectItem>
                 ))}
+                <SelectItem value="__add__">追加</SelectItem>
               </SelectContent>
             </Select>
             {gradeError && <p className="mt-2 text-sm text-red-500">{gradeError}</p>}

--- a/app/events/[eventId]/components/SchedulePage.tsx
+++ b/app/events/[eventId]/components/SchedulePage.tsx
@@ -26,15 +26,16 @@ import BestTimeSlots from './BestTimeSlots'
 import { createEmptySchedule } from './utils'
 import type { Participant, Schedule } from './types'
 import { useParams } from 'next/navigation'
-import { gradeOptions, ScheduleType } from './constants'
+import { ScheduleType } from './constants'
 
 type Props = {
   xAxis: string[]
   yAxis: string[]
   scheduleTypes: ScheduleType[]
+  gradeOptions: string[]
 }
 
-export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
+export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions }: Props) {
   const defaultTypeId = scheduleTypes.find((t) => t.isAvailable)?.id || ''
   const [participants, setParticipants] = useState<Participant[]>([])
   const [availableOptions, setAvailableOptions] = useState<string[]>([])
@@ -122,7 +123,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
     link.remove()
   }
 
-  // 学年フィルタリング
+  // 所属/役職フィルタリング
   const filteredParticipants =
     filterGrades.length === 0
       ? participants
@@ -209,13 +210,14 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
             xAxis={xAxis}
             yAxis={yAxis}
             availableOptions={availableOptions}
+            gradeOptions={gradeOptions}
           />
         </TabsContent>
 
         <TabsContent value="summary">
            <div className="mb-4 p-4 bg-gray-50 rounded-lg border">
         <div className="flex items-center justify-between mb-3">
-          <Label className="text-sm font-medium">学年で絞り込み</Label>
+          <Label className="text-sm font-medium">所属/役職で絞り込み</Label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={() => setFilterGrades(gradeOptions)} className="text-xs">
               全選択
@@ -263,7 +265,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
 
         {filterGrades.length > 0 && (
           <div className="mt-3 text-sm text-gray-600">
-            {filterGrades.length}個の学年を選択中 ({filteredParticipants.length}名が対象)
+            {filterGrades.length}個の所属/役職を選択中 ({filteredParticipants.length}名が対象)
           </div>
         )}
       </div>
@@ -284,7 +286,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
           </div>
 
           <div className="mt-12">
-            <h3 className="text-xl font-semibold mb-4">学年別集計（全体表示）</h3>
+            <h3 className="text-xl font-semibold mb-4">所属/役職別集計（全体表示）</h3>
             <div className="space-y-8">
               {gradeOptions.map((g) => {
                 const group = participants.filter((p) => p.grade === g)

--- a/app/events/[eventId]/components/constants.ts
+++ b/app/events/[eventId]/components/constants.ts
@@ -25,6 +25,7 @@ export type EventData = {
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
+  gradeOptions: string[]
 }
 
 // スケジュールの種類と対応する表示色など
@@ -41,7 +42,9 @@ export const scheduleTypes = [
 // 曜日と時限の定義
 export const days = ["月", "火", "水", "木", "金"]
 export const periods = [1, 2, 3, 4, 5]
-export const gradeOptions = [
+
+// 所属/役職のデフォルト値
+export const defaultGradeOptions = [
   'Teacher',
   'Dr',
   'M2',
@@ -53,7 +56,7 @@ export const gradeOptions = [
   'Others',
 ]
 
-export const gradeOrder: { [key: string]: number } = {
+export const defaultGradeOrder: { [key: string]: number } = {
   Teacher: 1,
   Dr: 2,
   M2: 3,


### PR DESCRIPTION
## Summary
- replace fixed "学年" field with customizable "所属/役職" options
- allow event creators and participants to add affiliation choices
- persist new affiliations and include them in analytics

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c93e0ee88328bdab1c2ba159968a