### PR TITLE
feat: customize affiliations and allow user-defined options

### DIFF
--- a/app/api/events/[eventId]/participants/[participantId]/route.ts
+++ b/app/api/events/[eventId]/participants/[participantId]/route.ts
@@ -7,13 +7,16 @@ export async function PUT(
   { params }: { params: { eventId: string; participantId: string } }
 ) {
   const { eventId, participantId } = await params
-  const { name, grade, schedule } = await req.json()
+  const { name, grade, gradePriority, schedule } = await req.json()
 
   if (!name || typeof name !== 'string') {
     return NextResponse.json({ error: '名前が必要です' }, { status: 400 })
   }  
   if (!grade || typeof grade !== 'string') {
     return NextResponse.json({ error: '所属/役職が必要です' }, { status: 400 })
+  }
+  if (gradePriority != null && typeof gradePriority !== 'number') {
+    return NextResponse.json({ error: 'gradePriority は数値で指定してください' }, { status: 400 })
   }
   if (!schedule || typeof schedule !== 'object') {
     return NextResponse.json({ error: 'スケジュールが必要です' }, { status: 400 })
@@ -32,9 +35,13 @@ export async function PUT(
         updatedAt: FieldValue.serverTimestamp(),
       })
 
-    await db.collection('events').doc(eventId).update({
+    const updateData: Record<string, any> = {
       gradeOptions: FieldValue.arrayUnion(grade),
-    })
+    }
+    if (gradePriority != null) {
+      updateData[`gradeOrder.${grade}`] = gradePriority
+    }
+    await db.collection('events').doc(eventId).update(updateData)
     return NextResponse.json({ message: '更新しました' })
   } catch (err) {
     console.error('更新エラー:', err)

--- a/app/api/events/[eventId]/participants/[participantId]/route.ts
+++ b/app/api/events/[eventId]/participants/[participantId]/route.ts
@@ -39,9 +39,9 @@ export async function PUT(
       gradeOptions: FieldValue.arrayUnion(grade),
     }
     if (gradePriority != null) {
-      updateData[`gradeOrder.${grade}`] = gradePriority
+      updateData.gradeOrder = { [grade]: gradePriority }
     }
-    await db.collection('events').doc(eventId).update(updateData)
+    await db.collection('events').doc(eventId).set(updateData, { merge: true })
     return NextResponse.json({ message: '更新しました' })
   } catch (err) {
     console.error('更新エラー:', err)

--- a/app/api/events/[eventId]/participants/[participantId]/route.ts
+++ b/app/api/events/[eventId]/participants/[participantId]/route.ts
@@ -13,7 +13,7 @@ export async function PUT(
     return NextResponse.json({ error: '名前が必要です' }, { status: 400 })
   }  
   if (!grade || typeof grade !== 'string') {
-    return NextResponse.json({ error: '学年が必要です' }, { status: 400 })
+    return NextResponse.json({ error: '所属/役職が必要です' }, { status: 400 })
   }
   if (!schedule || typeof schedule !== 'object') {
     return NextResponse.json({ error: 'スケジュールが必要です' }, { status: 400 })
@@ -31,6 +31,10 @@ export async function PUT(
         schedule,
         updatedAt: FieldValue.serverTimestamp(),
       })
+
+    await db.collection('events').doc(eventId).update({
+      gradeOptions: FieldValue.arrayUnion(grade),
+    })
     return NextResponse.json({ message: '更新しました' })
   } catch (err) {
     console.error('更新エラー:', err)

--- a/app/api/events/[eventId]/participants/route.ts
+++ b/app/api/events/[eventId]/participants/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "名前が必要です" }, { status: 400 })
   }
   if (!grade || typeof grade !== "string") {
-    return NextResponse.json({ error: "学年が必要です" }, { status: 400 })
+    return NextResponse.json({ error: "所属/役職が必要です" }, { status: 400 })
   }
   if (!schedule || typeof schedule !== "object") {
     return NextResponse.json({ error: "スケジュールが必要です" }, { status: 400 })
@@ -47,6 +47,10 @@ export async function POST(req: NextRequest) {
       grade,
       schedule,
       createdAt: FieldValue.serverTimestamp(),
+    })
+
+    await db.collection("events").doc(eventId).update({
+      gradeOptions: FieldValue.arrayUnion(grade),
     })
 
     return NextResponse.json({ message: "保存しました", id: docRef.id })

--- a/app/api/events/[eventId]/participants/route.ts
+++ b/app/api/events/[eventId]/participants/route.ts
@@ -56,9 +56,9 @@ export async function POST(req: NextRequest) {
       gradeOptions: FieldValue.arrayUnion(grade),
     }
     if (gradePriority != null) {
-      updateData[`gradeOrder.${grade}`] = gradePriority
+      updateData.gradeOrder = { [grade]: gradePriority }
     }
-    await db.collection("events").doc(eventId).update(updateData)
+    await db.collection("events").doc(eventId).set(updateData, { merge: true })
 
     return NextResponse.json({ message: "保存しました", id: docRef.id })
   } catch (err) {

--- a/app/api/events/[eventId]/route.ts
+++ b/app/api/events/[eventId]/route.ts
@@ -1,6 +1,7 @@
 // app/api/events/[eventId]/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/firebase"
+import { defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
 
 interface ScheduleType {
   id: string
@@ -64,6 +65,7 @@ export async function GET(
     description: data.description,
     eventType,
     scheduleTypes,
+    gradeOptions: Array.isArray(data.gradeOptions) ? data.gradeOptions : defaultGradeOptions,
     ...(eventType === "recurring"
       ? { xAxis, yAxis }
       : { dateTimeOptions }),
@@ -85,6 +87,7 @@ export async function PUT(
     xAxis,
     yAxis,
     dateTimeOptions,
+    gradeOptions,
   } = json
 
   // 基本バリデーション
@@ -122,6 +125,13 @@ export async function PUT(
       { error: "scheduleTypes は正しい形式で指定してください" },
       { status: 400 }
     )
+  }
+
+  if (
+    !Array.isArray(gradeOptions) ||
+    !gradeOptions.every((v: any) => typeof v === "string")
+  ) {
+    gradeOptions = defaultGradeOptions
   }
 
   // イベントタイプ別の検証
@@ -163,6 +173,7 @@ export async function PUT(
     description: description || "",
     eventType,
     scheduleTypes,
+    gradeOptions,
     updatedAt: new Date(),
   }
 

--- a/app/api/events/[eventId]/route.ts
+++ b/app/api/events/[eventId]/route.ts
@@ -1,7 +1,7 @@
 // app/api/events/[eventId]/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/firebase"
-import { defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
+import { defaultGradeOptions, defaultGradeOrder } from "@/app/events/[eventId]/components/constants"
 
 interface ScheduleType {
   id: string
@@ -66,6 +66,7 @@ export async function GET(
     eventType,
     scheduleTypes,
     gradeOptions: Array.isArray(data.gradeOptions) ? data.gradeOptions : defaultGradeOptions,
+    gradeOrder: typeof data.gradeOrder === 'object' ? data.gradeOrder : defaultGradeOrder,
     ...(eventType === "recurring"
       ? { xAxis, yAxis }
       : { dateTimeOptions }),
@@ -88,6 +89,7 @@ export async function PUT(
     yAxis,
     dateTimeOptions,
     gradeOptions,
+    gradeOrder,
   } = json
 
   // 基本バリデーション
@@ -134,6 +136,14 @@ export async function PUT(
     gradeOptions = defaultGradeOptions
   }
 
+  const order =
+    gradeOrder && typeof gradeOrder === "object"
+      ? Object.entries(gradeOrder).reduce((acc: any, [k, v]) => {
+          if (typeof k === "string" && typeof v === "number") acc[k] = v
+          return acc
+        }, {})
+      : defaultGradeOrder
+
   // イベントタイプ別の検証
   if (eventType === "recurring") {
     if (
@@ -174,6 +184,7 @@ export async function PUT(
     eventType,
     scheduleTypes,
     gradeOptions,
+    gradeOrder: order,
     updatedAt: new Date(),
   }
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,6 +1,7 @@
 // app/api/events/route.ts
 import { NextResponse, type NextRequest } from "next/server"
 import { db } from "@/lib/firebase"
+import { defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
 
 export async function POST(req: NextRequest) {
   const json = await req.json()
@@ -12,6 +13,7 @@ export async function POST(req: NextRequest) {
     yAxis,
     dateTimeOptions,
     scheduleTypes,
+    gradeOptions,
   } = json
 
   // --- 基本項目チェック ---
@@ -84,6 +86,11 @@ export async function POST(req: NextRequest) {
     )
   }
 
+  const grades =
+    Array.isArray(gradeOptions) && gradeOptions.every((v: any) => typeof v === "string")
+      ? gradeOptions
+      : defaultGradeOptions
+
   // --- Firestore に保存 ---
   try {
     const payload: any = {
@@ -91,6 +98,7 @@ export async function POST(req: NextRequest) {
       description: description || "",
       eventType,
       scheduleTypes,
+      gradeOptions: grades,
       createdAt: new Date(),
     }
     if (eventType === "recurring") {

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,7 +1,7 @@
 // app/api/events/route.ts
 import { NextResponse, type NextRequest } from "next/server"
 import { db } from "@/lib/firebase"
-import { defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
+import { defaultGradeOptions, defaultGradeOrder } from "@/app/events/[eventId]/components/constants"
 
 export async function POST(req: NextRequest) {
   const json = await req.json()
@@ -14,6 +14,7 @@ export async function POST(req: NextRequest) {
     dateTimeOptions,
     scheduleTypes,
     gradeOptions,
+    gradeOrder,
   } = json
 
   // --- 基本項目チェック ---
@@ -91,6 +92,14 @@ export async function POST(req: NextRequest) {
       ? gradeOptions
       : defaultGradeOptions
 
+  const order =
+    gradeOrder && typeof gradeOrder === "object"
+      ? Object.entries(gradeOrder).reduce((acc: any, [k, v]) => {
+          if (typeof k === "string" && typeof v === "number") acc[k] = v
+          return acc
+        }, {})
+      : defaultGradeOrder
+
   // --- Firestore に保存 ---
   try {
     const payload: any = {
@@ -99,6 +108,7 @@ export async function POST(req: NextRequest) {
       eventType,
       scheduleTypes,
       gradeOptions: grades,
+      gradeOrder: order,
       createdAt: new Date(),
     }
     if (eventType === "recurring") {

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -23,6 +23,7 @@ import {
   CalendarDays,
   Clock,
   FileText,
+  UserPlus,
 } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
@@ -34,7 +35,8 @@ import {
   onetimeTemplates,
   scheduleTypeTemplate,
   xAxisTemplate,
-  yAxisTemplate
+  yAxisTemplate,
+  defaultGradeOptions
 } from "../events/[eventId]/components/constants"
 import type { ScheduleType } from "../events/[eventId]/components/constants"
 
@@ -50,6 +52,9 @@ export default function HomePage() {
   // 単発イベント用の軸（日時の組み合わせ）
   const [dateTimeOptions, setDateTimeOptions] = useState(["5/1 19:00", "5/2 19:00", "5/3 20:00"])
 
+  // 所属/役職の選択肢
+  const [gradeOptions, setGradeOptions] = useState<string[]>(defaultGradeOptions)
+
   const [activeTab, setActiveTab] = useState("builder")
   const router = useRouter()
 
@@ -60,6 +65,7 @@ export default function HomePage() {
   const yAxisRefs = useRef<HTMLInputElement[]>([])
   const dateTimeRefs = useRef<HTMLInputElement[]>([])
   const typeLabelRefs = useRef<HTMLInputElement[]>([])
+  const gradeOptionRefs = useRef<HTMLInputElement[]>([])
 
   // X軸の項目を追加
   const addXItem = () => {
@@ -119,6 +125,33 @@ export default function HomePage() {
     const newOptions = [...dateTimeOptions]
     newOptions.splice(index, 1)
     setDateTimeOptions(newOptions)
+  }
+
+  // 所属/役職の項目を追加
+  const addGradeOption = () => {
+    setGradeOptions((prev) => {
+      const newOptions = [...prev, `選択肢${prev.length + 1}`]
+      requestAnimationFrame(() => {
+        const newIndex = newOptions.length - 1
+        gradeOptionRefs.current[newIndex]?.focus()
+      })
+      return newOptions
+    })
+  }
+
+  // 所属/役職の項目を削除
+  const removeGradeOption = (index: number) => {
+    if (gradeOptions.length <= 1) return
+    const newOpts = [...gradeOptions]
+    newOpts.splice(index, 1)
+    setGradeOptions(newOpts)
+  }
+
+  // 所属/役職の項目を更新
+  const updateGradeOption = (index: number, value: string) => {
+    const newOpts = [...gradeOptions]
+    newOpts[index] = value
+    setGradeOptions(newOpts)
   }
 
   // X軸の項目を更新
@@ -273,6 +306,7 @@ export default function HomePage() {
       const cleanedXAxis         = removeEmptyStrings(xAxis)
       const cleanedYAxis         = removeEmptyStrings(yAxis)
       const cleanedDateTimes     = removeEmptyStrings(dateTimeOptions)
+      const cleanedGrades        = removeEmptyStrings(gradeOptions)
 
       // イベントタイプに応じたデータを準備
       const eventData = {
@@ -280,6 +314,7 @@ export default function HomePage() {
         description: eventDesc,
         eventType,
         scheduleTypes: cleanedScheduleTypes,
+        gradeOptions: cleanedGrades,
         xAxis: eventType === "recurring" ? cleanedXAxis : undefined,
         yAxis: eventType === "recurring" ? cleanedYAxis : undefined,
         dateTimeOptions: eventType === "onetime" ? cleanedDateTimes : undefined,
@@ -402,6 +437,41 @@ export default function HomePage() {
               {eventType === "recurring"
                 ? "定期的なミーティングや授業など、曜日×時間のグリッド形式で調整します。"
                 : "単発のイベントや会議など、特定の日時のリストから選択して調整します。"}
+            </div>
+          </CardContent>
+        </Card>
+        {/* 所属/役職設定 */}
+        <Card className="bg-white dark:bg-gray-800 shadow-sm border">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-lg font-medium flex items-center gap-2">
+              <UserPlus className="h-5 w-5" />
+              所属/役職の選択肢
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {gradeOptions.map((opt, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <Input
+                    ref={(el) => (gradeOptionRefs.current[i] = el)}
+                    value={opt}
+                    onChange={(e) => updateGradeOption(i, e.target.value)}
+                    className="flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => removeGradeOption(i)}
+                    disabled={gradeOptions.length <= 1}
+                  >
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </div>
+              ))}
+              <Button type="button" variant="outline" size="sm" onClick={addGradeOption} className="mt-2">
+                <Plus className="h-4 w-4 mr-1" />追加
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -28,6 +28,7 @@ export default function EventPage() {
     dateTimeOptions: [],
     scheduleTypes: [],
     existingResponses: [],
+    gradeOptions: [],
   })
 
   // 編集用の状態
@@ -78,6 +79,7 @@ export default function EventPage() {
                 schedule: p.schedule,
               }))
             : [],
+          gradeOptions: Array.isArray(resData.gradeOptions) ? resData.gradeOptions : [],
         })
         setName(resData.name)
         setDescription(resData.description ?? "")
@@ -657,13 +659,19 @@ export default function EventPage() {
       {!editMode && (
         <div className="mt-6">
           {data.eventType === "recurring" ? (
-            <SchedulePage xAxis={data.xAxis} yAxis={data.yAxis} scheduleTypes={data.scheduleTypes} />
+            <SchedulePage
+              xAxis={data.xAxis}
+              yAxis={data.yAxis}
+              scheduleTypes={data.scheduleTypes}
+              gradeOptions={data.gradeOptions}
+            />
           ) : (
             <OneTimePage
               eventId={eventId ? String(eventId) : ""}
               dateTimeOptions={data.dateTimeOptions}
               scheduleTypes={data.scheduleTypes}
               responses={data.existingResponses}
+              gradeOptions={data.gradeOptions}
             />
           )}
         </div>

--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -13,7 +13,7 @@ import { Switch } from "@/components/ui/switch"
 import SchedulePage from "@/app/events/[eventId]/components/SchedulePage"
 import OneTimePage from "@/app/events/[eventId]/components/OneTimePage"
 import type { EventData, ScheduleType } from "@/app/events/[eventId]/components/constants"
-import { defaultGradeOrder } from "@/app/events/[eventId]/components/constants"
+import { defaultGradeOrder, defaultGradeOptions } from "@/app/events/[eventId]/components/constants"
 import { colorPalettes } from "@/app/events/[eventId]/components/constants"
 import Link from "next/link"
 
@@ -44,12 +44,14 @@ export default function EventPage() {
   const [editYAxis, setEditYAxis] = useState<string[]>([])
   const [editDateTimeOptions, setEditDateTimeOptions] = useState<string[]>([])
   const [editScheduleTypes, setEditScheduleTypes] = useState<ScheduleType[]>([])
+  const [editGradeOptions, setEditGradeOptions] = useState<{ name: string; priority: number }[]>([])
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const xAxisRefs = useRef<HTMLInputElement[]>([])
   const yAxisRefs = useRef<HTMLInputElement[]>([])
   const dateTimeRefs = useRef<HTMLInputElement[]>([])
   const typeLabelRefs = useRef<HTMLInputElement[]>([])
+  const gradeOptionRefs = useRef<HTMLInputElement[]>([])
 
   // イベント情報の取得
   useEffect(() => {
@@ -90,6 +92,22 @@ export default function EventPage() {
         setEditYAxis(Array.isArray(resData.yAxis) ? [...resData.yAxis] : [])
         setEditDateTimeOptions(Array.isArray(resData.dateTimeOptions) ? [...resData.dateTimeOptions] : [])
         setEditScheduleTypes(Array.isArray(resData.scheduleTypes) ? [...resData.scheduleTypes] : [])
+        setEditGradeOptions(
+          Array.isArray(resData.gradeOptions)
+            ? resData.gradeOptions
+                .map((g: string) => ({
+                  name: g,
+                  priority:
+                    (resData.gradeOrder && typeof resData.gradeOrder[g] === "number"
+                      ? resData.gradeOrder[g]
+                      : defaultGradeOrder[g]) ?? 0,
+                }))
+                .sort((a, b) => a.priority - b.priority)
+            : defaultGradeOptions.map((g) => ({
+                name: g,
+                priority: defaultGradeOrder[g] ?? 0,
+              }))
+        )
       })
       .catch((err) => {
         console.error(err)
@@ -244,6 +262,43 @@ export default function EventPage() {
     setEditScheduleTypes(newTypes)
   }
 
+  // 所属/役職の項目を追加
+  const addGradeOption = () => {
+    setEditGradeOptions((prev) => {
+      const newOptions = [
+        ...prev,
+        { name: `選択肢${prev.length + 1}`, priority: prev.length + 1 },
+      ]
+      requestAnimationFrame(() => {
+        const newIndex = newOptions.length - 1
+        gradeOptionRefs.current[newIndex]?.focus()
+      })
+      return newOptions
+    })
+  }
+
+  // 所属/役職の項目を削除
+  const removeGradeOption = (index: number) => {
+    if (editGradeOptions.length <= 1) return
+    const newOpts = [...editGradeOptions]
+    newOpts.splice(index, 1)
+    setEditGradeOptions(newOpts)
+  }
+
+  // 所属/役職の名称を更新
+  const updateGradeOptionName = (index: number, value: string) => {
+    const newOpts = [...editGradeOptions]
+    newOpts[index].name = value
+    setEditGradeOptions(newOpts)
+  }
+
+  // 所属/役職の優先度を更新
+  const updateGradeOptionPriority = (index: number, value: number) => {
+    const newOpts = [...editGradeOptions]
+    newOpts[index].priority = value
+    setEditGradeOptions(newOpts)
+  }
+
   // 編集をキャンセル
   const cancelEdit = () => {
     setName(data.name)
@@ -252,6 +307,12 @@ export default function EventPage() {
     setEditYAxis([...data.yAxis])
     setEditDateTimeOptions([...data.dateTimeOptions])
     setEditScheduleTypes([...data.scheduleTypes])
+    setEditGradeOptions(
+      data.gradeOptions.map((g) => ({
+        name: g,
+        priority: data.gradeOrder[g] ?? 0,
+      }))
+    )
     setEditMode(false)
     setActiveTab("basic")
   }
@@ -317,12 +378,20 @@ export default function EventPage() {
       const cleanedXAxis         = removeEmptyStrings(editXAxis)
       const cleanedYAxis         = removeEmptyStrings(editYAxis)
       const cleanedDateTimes     = removeEmptyStrings(editDateTimeOptions)
+      const cleanedGrades        = editGradeOptions.filter((o) => o.name.trim() !== "")
+      const gradeOptions         = cleanedGrades.map((o) => o.name)
+      const gradeOrder: Record<string, number> = {}
+      cleanedGrades.forEach((o) => {
+        gradeOrder[o.name] = o.priority
+      })
       // イベントタイプに応じたデータを準備
       const updateData = {
         name,
         description,
         eventType: data.eventType,
         scheduleTypes: cleanedScheduleTypes,
+        gradeOptions,
+        gradeOrder,
         ...(data.eventType === "recurring"
           ? { xAxis: cleanedXAxis, yAxis: cleanedYAxis }
           : { dateTimeOptions: cleanedDateTimes }),
@@ -348,7 +417,13 @@ export default function EventPage() {
         yAxis: cleanedYAxis,
         dateTimeOptions: cleanedDateTimes,
         scheduleTypes: cleanedScheduleTypes,
+        gradeOptions: gradeOptions.sort(
+          (a, b) => (gradeOrder[a] ?? 999) - (gradeOrder[b] ?? 999)
+        ),
+        gradeOrder,
       }))
+
+      setEditGradeOptions(cleanedGrades)
 
       setEditMode(false)
     } catch (err: any) {
@@ -373,6 +448,7 @@ export default function EventPage() {
               <TabsTrigger value="basic">基本情報</TabsTrigger>
               <TabsTrigger value="options">{data.eventType === "recurring" ? "グリッド設定" : "日時設定"}</TabsTrigger>
               <TabsTrigger value="types">回答タイプ</TabsTrigger>
+              <TabsTrigger value="grades">所属/役職</TabsTrigger>
             </TabsList>
 
             {/* 基本情報タブ */}
@@ -625,6 +701,46 @@ export default function EventPage() {
                     </div>
                   </div>
                 ))}
+              </div>
+            </TabsContent>
+
+            {/* 所属/役職タブ */}
+            <TabsContent value="grades" className="space-y-4">
+              <div className="space-y-2">
+                {editGradeOptions.map((opt, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <Input
+                      ref={(el) => (gradeOptionRefs.current[i] = el)}
+                      value={opt.name}
+                      onChange={(e) => updateGradeOptionName(i, e.target.value)}
+                      className="flex-1"
+                    />
+                    <Input
+                      type="number"
+                      value={opt.priority}
+                      onChange={(e) => updateGradeOptionPriority(i, Number(e.target.value))}
+                      className="w-24"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeGradeOption(i)}
+                      disabled={editGradeOptions.length <= 1}
+                    >
+                      <Trash2 className="h-4 w-4 text-red-500" />
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addGradeOption}
+                  className="mt-2"
+                >
+                  <Plus className="h-4 w-4 mr-1" />追加
+                </Button>
               </div>
             </TabsContent>
           </Tabs>

--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -13,6 +13,7 @@ import { Switch } from "@/components/ui/switch"
 import SchedulePage from "@/app/events/[eventId]/components/SchedulePage"
 import OneTimePage from "@/app/events/[eventId]/components/OneTimePage"
 import type { EventData, ScheduleType } from "@/app/events/[eventId]/components/constants"
+import { defaultGradeOrder } from "@/app/events/[eventId]/components/constants"
 import { colorPalettes } from "@/app/events/[eventId]/components/constants"
 import Link from "next/link"
 
@@ -29,6 +30,7 @@ export default function EventPage() {
     scheduleTypes: [],
     existingResponses: [],
     gradeOptions: [],
+    gradeOrder: defaultGradeOrder,
   })
 
   // 編集用の状態
@@ -79,7 +81,8 @@ export default function EventPage() {
                 schedule: p.schedule,
               }))
             : [],
-          gradeOptions: Array.isArray(resData.gradeOptions) ? resData.gradeOptions : [],
+          gradeOptions: Array.isArray(resData.gradeOptions) ? resData.gradeOptions.sort((a: string,b: string)=>(resData.gradeOrder?.[a]??999)-(resData.gradeOrder?.[b]??999)) : [],
+          gradeOrder: typeof resData.gradeOrder === 'object' ? resData.gradeOrder : defaultGradeOrder,
         })
         setName(resData.name)
         setDescription(resData.description ?? "")
@@ -664,6 +667,7 @@ export default function EventPage() {
               yAxis={data.yAxis}
               scheduleTypes={data.scheduleTypes}
               gradeOptions={data.gradeOptions}
+              gradeOrder={data.gradeOrder}
             />
           ) : (
             <OneTimePage
@@ -672,6 +676,7 @@ export default function EventPage() {
               scheduleTypes={data.scheduleTypes}
               responses={data.existingResponses}
               gradeOptions={data.gradeOptions}
+              gradeOrder={data.gradeOrder}
             />
           )}
         </div>

--- a/app/events/[eventId]/analytics/page.tsx
+++ b/app/events/[eventId]/analytics/page.tsx
@@ -20,7 +20,6 @@ import {
 } from "recharts"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import type { ScheduleType } from "@/app/events/[eventId]/components/constants"
-import { gradeOptions } from "@/app/events/[eventId]/components/constants"
 
 type AnalyticsResponse = {
   id: string
@@ -34,6 +33,7 @@ export default function AnalyticsPage() {
   const [eventName, setEventName] = useState("読み込み中...")
   const [scheduleTypes, setScheduleTypes] = useState<ScheduleType[]>([])
   const [responses, setResponses] = useState<AnalyticsResponse[]>([])
+  const [gradeOptions, setGradeOptions] = useState<string[]>([])
 
   useEffect(() => {
     if (!eventId) return
@@ -42,6 +42,7 @@ export default function AnalyticsPage() {
       .then((data) => {
         setEventName(data.name || "")
         setScheduleTypes(Array.isArray(data.scheduleTypes) ? data.scheduleTypes : [])
+        setGradeOptions(Array.isArray(data.gradeOptions) ? data.gradeOptions : [])
         setResponses(
           Array.isArray(data.participants)
             ? data.participants.map((p: any) => ({
@@ -116,7 +117,7 @@ export default function AnalyticsPage() {
         grade: g,
         count: gradeCounts[g] || 0,
       })),
-    [gradeCounts],
+    [gradeCounts, gradeOptions],
   )
 
   const barConfig = { count: { label: "人数", color: "hsl(var(--chart-1))" } }
@@ -155,7 +156,7 @@ export default function AnalyticsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>学年別参加人数</CardTitle>
+          <CardTitle>所属/役職別参加人数</CardTitle>
         </CardHeader>
         <CardContent>
           <ChartContainer config={barConfig} className="h-[300px] w-full">

--- a/app/events/[eventId]/analytics/page.tsx
+++ b/app/events/[eventId]/analytics/page.tsx
@@ -34,7 +34,7 @@ export default function AnalyticsPage() {
   const [scheduleTypes, setScheduleTypes] = useState<ScheduleType[]>([])
   const [responses, setResponses] = useState<AnalyticsResponse[]>([])
   const [gradeOptions, setGradeOptions] = useState<string[]>([])
-
+  
   useEffect(() => {
     if (!eventId) return
     fetch(`/api/events/${eventId}`)
@@ -42,7 +42,13 @@ export default function AnalyticsPage() {
       .then((data) => {
         setEventName(data.name || "")
         setScheduleTypes(Array.isArray(data.scheduleTypes) ? data.scheduleTypes : [])
-        setGradeOptions(Array.isArray(data.gradeOptions) ? data.gradeOptions : [])
+        if (Array.isArray(data.gradeOptions)) {
+          const order = data.gradeOrder || {}
+          const sorted = [...data.gradeOptions].sort(
+            (a: string, b: string) => (order[a] ?? 999) - (order[b] ?? 999)
+          )
+          setGradeOptions(sorted)
+        }
         setResponses(
           Array.isArray(data.participants)
             ? data.participants.map((p: any) => ({

--- a/app/events/[eventId]/components/OneTimeInput.tsx
+++ b/app/events/[eventId]/components/OneTimeInput.tsx
@@ -10,7 +10,7 @@ import {
   X,
   GraduationCap,
 } from "lucide-react"
-import { type ScheduleType, type Response, gradeOptions } from "./constants"
+import { type ScheduleType, type Response } from "./constants"
 import { toast } from "@/components/ui/use-toast"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -33,6 +33,8 @@ type Props = {
   existingResponses: Response[]
   setExistingResponses: React.Dispatch<React.SetStateAction<Response[]>>
   setActiveTab: (tab: string) => void
+  gradeOptions: string[]
+  setGradeOptions: React.Dispatch<React.SetStateAction<string[]>>
 }
 
 export default function OneTimeInputTab({
@@ -42,6 +44,8 @@ export default function OneTimeInputTab({
   existingResponses = [],
   setExistingResponses,
   setActiveTab,
+  gradeOptions,
+  setGradeOptions,
 }: Props) {
   const [name, setName] = useState("")
   const [grade, setGrade] = useState("")
@@ -161,7 +165,7 @@ export default function OneTimeInputTab({
           await handleSubmit()
         }}
       >
-        {/* 名前と学年 */}
+        {/* 名前と所属/役職 */}
         <Card className="mb-4">
           <CardContent className="pt-4 pb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
@@ -180,11 +184,27 @@ export default function OneTimeInputTab({
             <div>
               <Label htmlFor="participant-grade" className="text-sm font-medium mb-1 block">
                 <GraduationCap className="h-4 w-4 inline-block mr-1" />
-                学年
+                所属/役職
               </Label>
-              <Select value={grade} onValueChange={(v) => setGrade(v)}>
+              <Select
+                value={grade}
+                onValueChange={(v) => {
+                  if (v === "__add__") {
+                    const newGrade = prompt("所属/役職を入力してください")
+                    if (newGrade) {
+                      const trimmed = newGrade.trim()
+                      if (trimmed && !gradeOptions.includes(trimmed)) {
+                        setGradeOptions([...gradeOptions, trimmed])
+                      }
+                      setGrade(trimmed)
+                    }
+                    return
+                  }
+                  setGrade(v)
+                }}
+              >
                 <SelectTrigger id="participant-grade">
-                  <SelectValue placeholder="学年を選択してください" />
+                  <SelectValue placeholder="所属/役職を選択してください" />
                 </SelectTrigger>
                 <SelectContent>
                   {gradeOptions.map((opt) => (
@@ -192,6 +212,7 @@ export default function OneTimeInputTab({
                       {opt}
                     </SelectItem>
                   ))}
+                  <SelectItem value="__add__">追加</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/app/events/[eventId]/components/OneTimeInput.tsx
+++ b/app/events/[eventId]/components/OneTimeInput.tsx
@@ -34,7 +34,8 @@ type Props = {
   setExistingResponses: React.Dispatch<React.SetStateAction<Response[]>>
   setActiveTab: (tab: string) => void
   gradeOptions: string[]
-  setGradeOptions: React.Dispatch<React.SetStateAction<string[]>>
+  gradeOrder: { [key: string]: number }
+  addGradeOption: (name: string, priority: number) => void
 }
 
 export default function OneTimeInputTab({
@@ -45,7 +46,8 @@ export default function OneTimeInputTab({
   setExistingResponses,
   setActiveTab,
   gradeOptions,
-  setGradeOptions,
+  gradeOrder,
+  addGradeOption,
 }: Props) {
   const [name, setName] = useState("")
   const [grade, setGrade] = useState("")
@@ -101,6 +103,7 @@ export default function OneTimeInputTab({
         eventId,
         name,
         grade,
+        gradePriority: gradeOrder[grade],
         schedule: Object.entries(selections).map(([dateTime, typeId]) => ({
           dateTime,
           typeId,
@@ -193,9 +196,9 @@ export default function OneTimeInputTab({
                     const newGrade = prompt("所属/役職を入力してください")
                     if (newGrade) {
                       const trimmed = newGrade.trim()
-                      if (trimmed && !gradeOptions.includes(trimmed)) {
-                        setGradeOptions([...gradeOptions, trimmed])
-                      }
+                      const pr = prompt("優先度を入力してください（数値）")
+                      const priority = pr ? Number(pr) : gradeOptions.length + 1
+                      addGradeOption(trimmed, priority)
                       setGrade(trimmed)
                     }
                     return

--- a/app/events/[eventId]/components/OneTimeInput.tsx
+++ b/app/events/[eventId]/components/OneTimeInput.tsx
@@ -196,8 +196,26 @@ export default function OneTimeInputTab({
                     const newGrade = prompt("所属/役職を入力してください")
                     if (newGrade) {
                       const trimmed = newGrade.trim()
-                      const pr = prompt("優先度を入力してください（数値）")
-                      const priority = pr ? Number(pr) : gradeOptions.length + 1
+                      const existing = gradeOptions
+                        .map((g) => `${g}(${gradeOrder[g] ?? "-"})`)
+                        .join("\n")
+                      const pr = prompt(
+                        `優先度を入力してください（1〜999の半角数字。小さい数字ほど優先度が高く表示順が前になります）\n現在の設定:\n${existing}`
+                      )
+                      let priority: number
+                      if (!pr || pr.trim() === "") {
+                        const maxPri = Math.max(0, ...Object.values(gradeOrder))
+                        priority = maxPri + 1
+                      } else if (/^\d+$/.test(pr.trim())) {
+                        priority = Number(pr)
+                        if (priority < 1 || priority > 999) {
+                          alert("優先度は1〜999の半角数字で入力してください")
+                          return
+                        }
+                      } else {
+                        alert("優先度は1〜999の半角数字で入力してください")
+                        return
+                      }
                       addGradeOption(trimmed, priority)
                       setGrade(trimmed)
                     }
@@ -212,7 +230,7 @@ export default function OneTimeInputTab({
                 <SelectContent>
                   {gradeOptions.map((opt) => (
                     <SelectItem key={opt} value={opt}>
-                      {opt}
+                      {opt} (優先度: {gradeOrder[opt]})
                     </SelectItem>
                   ))}
                   <SelectItem value="__add__">追加</SelectItem>

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -27,6 +27,7 @@ type Props = {
   responses?: Response[]
   form: ParticipantFormHook
   gradeOptions: string[]
+  gradeOrder: { [key: string]: number }
 }
 
 export default function OneTimeResponsesTab({
@@ -35,6 +36,7 @@ export default function OneTimeResponsesTab({
   responses = [],
   form,
   gradeOptions,
+  gradeOrder,
 }: Props) {
   // 
   const getResponseIcon = (response: Response, dateTime: string) => {

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -78,7 +78,10 @@ export default function OneTimeResponsesTab({
     return bgClass
   } 
 
-  const sorted = form.getSortedResponses() // ここがうまく動いてない
+  // `getSortedResponses` should always return an array, but guard just in case
+  const sortedRaw = form.getSortedResponses()
+  const sorted = Array.isArray(sortedRaw) ? sortedRaw : []
+  const gradeOpts = Array.isArray(gradeOptions) ? gradeOptions : []
 
   const availableTypeIds = scheduleTypes
     .filter((t) => t.isAvailable)
@@ -197,7 +200,7 @@ export default function OneTimeResponsesTab({
                     {/* 所属/役職 */}
                     <div className="space-y-2">
                       <div className="grid grid-cols-2 gap-2">
-                        {gradeOptions.map((g) => (
+                        {gradeOpts.map((g) => (
                           <label key={g} className="flex items-center space-x-2 text-xs">
                             <Checkbox
                               checked={form.filterGrades.includes(g)}

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -10,7 +10,6 @@ import {
   Pencil,
 } from "lucide-react"
 import type { ScheduleType, Response } from "./constants"
-import { gradeOptions } from "./constants"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent  } from "@/components/ui/card"
@@ -27,6 +26,7 @@ type Props = {
   scheduleTypes: ScheduleType[]
   responses?: Response[]
   form: ParticipantFormHook
+  gradeOptions: string[]
 }
 
 export default function OneTimeResponsesTab({
@@ -34,6 +34,7 @@ export default function OneTimeResponsesTab({
   scheduleTypes,
   responses = [],
   form,
+  gradeOptions,
 }: Props) {
   // 
   const getResponseIcon = (response: Response, dateTime: string) => {
@@ -100,7 +101,7 @@ export default function OneTimeResponsesTab({
               <div className="relative w-full md:w-40">
                 <Search className="absolute left-2 top-2 h-3 w-3 text-gray-400" />
                 <Input
-                  placeholder="名前 or 学年で検索..."
+                  placeholder="名前 or 所属/役職で検索..."
                   value={form.searchQuery}
                   onChange={(e) => form.setSearchQuery(e.target.value)}
                   className="pl-7 h-8 text-xs"
@@ -122,7 +123,7 @@ export default function OneTimeResponsesTab({
                   className="h-8 text-xs"
                   onClick={() => form.handleSort("grade")}
                 >
-                  学年{form.sortColumn === "grade" && (form.sortDirection === "asc" ? "↑" : "↓")}
+                  所属/役職{form.sortColumn === "grade" && (form.sortDirection === "asc" ? "↑" : "↓")}
                 </Button>
                 <Button
                   variant={form.sortColumn === "availability" ? "default" : "outline"}
@@ -191,7 +192,7 @@ export default function OneTimeResponsesTab({
                         </SelectContent>
                       </Select>
                     </div>
-                    {/* 学年 */}
+                    {/* 所属/役職 */}
                     <div className="space-y-2">
                       <div className="grid grid-cols-2 gap-2">
                         {gradeOptions.map((g) => (

--- a/app/events/[eventId]/components/OneTimeSummary.tsx
+++ b/app/events/[eventId]/components/OneTimeSummary.tsx
@@ -23,10 +23,11 @@ export default function OneTimeSummaryTab({
   gradeOrder,
 }: Props) {
   const [summaryView, setSummaryView] = useState<"dates" | "grades">("dates")
+  const responses = Array.isArray(existingResponses) ? existingResponses : []
 
   // 指定日時の「参加可能」人数
   const getAvailableCount = (dateTime: string) =>
-    existingResponses.filter((response) => {
+    responses.filter((response) => {
       const sel = response.schedule.find((s) => s.dateTime === dateTime)
       if (!sel) return false
       const type = scheduleTypes.find((t) => t.id === sel.typeId)
@@ -35,7 +36,7 @@ export default function OneTimeSummaryTab({
 
   // 指定日時・指定タイプに回答した人の名前リスト
   const getRespondentsByType = (dateTime: string, typeId: string) =>
-    existingResponses
+    responses
       .filter((response) =>
         response.schedule.some((s) => s.dateTime === dateTime && s.typeId === typeId)
       )
@@ -47,7 +48,7 @@ export default function OneTimeSummaryTab({
 
   // 指定所属/役職・指定日時の「参加可能」人数
   const getAvailableCountByGradeAndDateTime = (grade: string, dateTime: string) =>
-    existingResponses.filter((response) => {
+    responses.filter((response) => {
       if (response.grade !== grade) return false
       const sel = response.schedule.find((s) => s.dateTime === dateTime)
       if (!sel) return false
@@ -59,7 +60,7 @@ export default function OneTimeSummaryTab({
   const getResponseTypeDistributionByGrade = (grade: string) => {
     const dist: Record<string, number> = {}
     scheduleTypes.forEach((t) => (dist[t.id] = 0))
-    existingResponses
+    responses
       .filter((r) => r.grade === grade)
       .forEach((r) =>
         r.schedule.forEach((s) => {
@@ -71,7 +72,7 @@ export default function OneTimeSummaryTab({
 
   // 最適日時を取得
   const getBestDateTime = () => {
-    if (!dateTimeOptions.length || !existingResponses.length) return null
+    if (!dateTimeOptions.length || !responses.length) return null
     let best = dateTimeOptions[0]
     let maxCount = getAvailableCount(best)
     dateTimeOptions.forEach((dt) => {
@@ -88,7 +89,7 @@ export default function OneTimeSummaryTab({
 
   return (
     <TabsContent value="summary" className="space-y-4">
-      {existingResponses.length > 0 ? (
+      {responses.length > 0 ? (
         <div className="space-y-4">
           {/* 表示切り替えタブ */}
           <div className="flex justify-between items-center">
@@ -285,7 +286,7 @@ export default function OneTimeSummaryTab({
                       </thead>
                       <tbody className="divide-y">
                         {Object.entries(
-                          existingResponses.reduce(
+                          responses.reduce(
                             (acc, r) => {
                               const g = r.grade || "未設定"
                               if (!acc[g]) acc[g] = []
@@ -351,7 +352,7 @@ export default function OneTimeSummaryTab({
                 <CardContent>
                   <div className="space-y-4">
                     {Object.entries(
-                      existingResponses.reduce(
+                      responses.reduce(
                         (acc, r) => {
                           const g = r.grade || "未設定"
                           if (!acc[g]) acc[g] = []

--- a/app/events/[eventId]/components/OneTimeSummary.tsx
+++ b/app/events/[eventId]/components/OneTimeSummary.tsx
@@ -12,6 +12,7 @@ type Props = {
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
   gradeOptions: string[]
+  gradeOrder: { [key: string]: number }
 }
 
 export default function OneTimeSummaryTab({
@@ -19,12 +20,9 @@ export default function OneTimeSummaryTab({
   scheduleTypes,
   existingResponses,
   gradeOptions,
+  gradeOrder,
 }: Props) {
   const [summaryView, setSummaryView] = useState<"dates" | "grades">("dates")
-
-  const gradeOrder = useMemo(() => {
-    return gradeOptions.reduce((acc, g, i) => ({ ...acc, [g]: i }), {} as Record<string, number>)
-  }, [gradeOptions])
 
   // 指定日時の「参加可能」人数
   const getAvailableCount = (dateTime: string) =>

--- a/app/events/[eventId]/components/OneTimeSummary.tsx
+++ b/app/events/[eventId]/components/OneTimeSummary.tsx
@@ -1,25 +1,30 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useState, useMemo } from "react"
 import { TabsContent } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar, GraduationCap, Clock, PieChart } from "lucide-react"
 import type { ScheduleType, Response } from "./constants"
-import { gradeOrder } from "./constants"
 
 type Props = {
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
+  gradeOptions: string[]
 }
 
 export default function OneTimeSummaryTab({
   dateTimeOptions,
   scheduleTypes,
   existingResponses,
+  gradeOptions,
 }: Props) {
   const [summaryView, setSummaryView] = useState<"dates" | "grades">("dates")
+
+  const gradeOrder = useMemo(() => {
+    return gradeOptions.reduce((acc, g, i) => ({ ...acc, [g]: i }), {} as Record<string, number>)
+  }, [gradeOptions])
 
   // 指定日時の「参加可能」人数
   const getAvailableCount = (dateTime: string) =>
@@ -42,7 +47,7 @@ export default function OneTimeSummaryTab({
   const getResponseCountByType = (dateTime: string, typeId: string) =>
     getRespondentsByType(dateTime, typeId).length
 
-  // 指定学年・指定日時の「参加可能」人数
+  // 指定所属/役職・指定日時の「参加可能」人数
   const getAvailableCountByGradeAndDateTime = (grade: string, dateTime: string) =>
     existingResponses.filter((response) => {
       if (response.grade !== grade) return false
@@ -52,7 +57,7 @@ export default function OneTimeSummaryTab({
       return type?.isAvailable
     }).length
 
-  // 指定学年の回答タイプ分布
+  // 指定所属/役職の回答タイプ分布
   const getResponseTypeDistributionByGrade = (grade: string) => {
     const dist: Record<string, number> = {}
     scheduleTypes.forEach((t) => (dist[t.id] = 0))
@@ -107,7 +112,7 @@ export default function OneTimeSummaryTab({
                 onClick={() => setSummaryView("grades")}
               >
                 <GraduationCap className="h-4 w-4 mr-1" />
-                学年別
+                所属/役職別
               </button>
             </div>
           </div>
@@ -245,13 +250,13 @@ export default function OneTimeSummaryTab({
               </CardContent>
             </Card>
           ) : (
-            /* 学年別の集計表 */
+            /* 所属/役職別の集計表 */
             <div className="space-y-4">
               <Card>
                 <CardHeader className="pb-2">
                   <CardTitle className="text-base font-medium flex items-center">
                     <GraduationCap className="h-4 w-4 mr-2" />
-                    学年別の参加状況
+                    所属/役職別の参加状況
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="p-0">
@@ -260,7 +265,7 @@ export default function OneTimeSummaryTab({
                       <thead>
                         <tr className="bg-gray-50 border-b">
                           <th className="text-left py-2 px-3 font-medium">
-                            学年
+                            所属/役職
                           </th>
                           <th className="py-2 px-2 text-center font-medium">
                             回答者数
@@ -294,8 +299,8 @@ export default function OneTimeSummaryTab({
                         )
                           .sort(
                             ([a], [b]) =>
-                              (gradeOrder[a as keyof typeof gradeOrder] || 999) -
-                              (gradeOrder[b as keyof typeof gradeOrder] || 999)
+                              (gradeOrder[a] ?? 999) -
+                              (gradeOrder[b] ?? 999)
                           )
                           .map(([g, names]) => (
                             <tr key={g} className="hover:bg-gray-50">
@@ -342,7 +347,7 @@ export default function OneTimeSummaryTab({
                 <CardHeader className="pb-2">
                   <CardTitle className="text-base font-medium flex items-center">
                     <PieChart className="h-4 w-4 mr-2" />
-                    学年別の詳細情報
+                    所属/役職別の詳細情報
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
@@ -360,8 +365,8 @@ export default function OneTimeSummaryTab({
                     )
                       .sort(
                         ([a], [b]) =>
-                          (gradeOrder[a as keyof typeof gradeOrder] || 999) -
-                          (gradeOrder[b as keyof typeof gradeOrder] || 999)
+                          (gradeOrder[a] ?? 999) -
+                          (gradeOrder[b] ?? 999)
                       )
                       .map(([g, names]) => {
                         const dist = getResponseTypeDistributionByGrade(g)

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -35,6 +35,7 @@ type Props = {
   xAxis: string[]
   yAxis: string[]
   availableOptions: string[]
+  gradeOptions: string[]
 }
 
 export default function ParticipantList({
@@ -48,12 +49,13 @@ export default function ParticipantList({
   xAxis,
   yAxis,
   availableOptions,
+  gradeOptions,
 }: Props) {
   const isMobile = useMediaQuery('(max-width: 768px)')
   const { eventId } = useParams()
 
-  // 学年フィルタ／ソート／ビュー切り替え
-  const gradeOrder = ['Teacher', 'Dr', 'M2', 'M1', 'B4', 'B3', 'B2', 'B1', 'Others']
+  // 所属/役職フィルタ／ソート／ビュー切り替え
+  const gradeOrder = gradeOptions
   const [filterGrade, setFilterGrade] = useState<string>('All')
   const [sortAscending, setSortAscending] = useState<boolean>(true)
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid')
@@ -127,13 +129,13 @@ export default function ParticipantList({
       {/* ── フィルタ／ソート／ビュー切替 ── */}
       <div className="flex flex-wrap items-center justify-between mb-4 gap-4">
         <div className="flex items-center gap-2">
-          <Label htmlFor="filter-grade">学年フィルタ</Label>
+          <Label htmlFor="filter-grade">所属/役職フィルタ</Label>
           <Select value={filterGrade} onValueChange={setFilterGrade}>
             <SelectTrigger id="filter-grade" className="w-36">
-              <SelectValue placeholder="全学年" />
+              <SelectValue placeholder="全て" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="All">全学年</SelectItem>
+              <SelectItem value="All">全て</SelectItem>
               {gradeOrder.map((g) => (
                 <SelectItem key={g} value={g}>
                   {g}
@@ -149,7 +151,7 @@ export default function ParticipantList({
             size="sm"
             onClick={() => setSortAscending((p) => !p)}
           >
-            {sortAscending ? '学年↑' : '学年↓'}
+            {sortAscending ? '所属/役職↑' : '所属/役職↓'}
           </Button>
 
           <Button

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -36,6 +36,7 @@ type Props = {
   yAxis: string[]
   availableOptions: string[]
   gradeOptions: string[]
+  gradeOrder: { [key: string]: number }
 }
 
 export default function ParticipantList({
@@ -50,12 +51,12 @@ export default function ParticipantList({
   yAxis,
   availableOptions,
   gradeOptions,
+  gradeOrder,
 }: Props) {
   const isMobile = useMediaQuery('(max-width: 768px)')
   const { eventId } = useParams()
 
   // 所属/役職フィルタ／ソート／ビュー切り替え
-  const gradeOrder = gradeOptions
   const [filterGrade, setFilterGrade] = useState<string>('All')
   const [sortAscending, setSortAscending] = useState<boolean>(true)
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid')
@@ -67,8 +68,8 @@ export default function ParticipantList({
       : participants.filter((p) => p.grade === filterGrade)
 
   displayed.sort((a, b) => {
-    const ai = gradeOrder.indexOf(a.grade)
-    const bi = gradeOrder.indexOf(b.grade)
+    const ai = gradeOrder[a.grade] ?? 999
+    const bi = gradeOrder[b.grade] ?? 999
     return sortAscending ? ai - bi : bi - ai
   })
 

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -137,7 +137,7 @@ export default function ParticipantList({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="All">全て</SelectItem>
-              {gradeOrder.map((g) => (
+              {gradeOptions.map((g) => (
                 <SelectItem key={g} value={g}>
                   {g}
                 </SelectItem>

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -22,6 +22,8 @@ type Props = {
   yAxis: string[]
   scheduleTypes: ScheduleType[]
   gradeOptions: string[]
+  gradeOrder: { [key: string]: number }
+  addGradeOption: (name: string, priority: number) => void
   currentName: string
   setCurrentName: Dispatch<SetStateAction<string>>
   currentGrade: string
@@ -40,6 +42,8 @@ export default function ScheduleForm({
   yAxis,
   scheduleTypes,
   gradeOptions,
+  gradeOrder,
+  addGradeOption,
   currentName,
   setCurrentName,
   currentGrade,
@@ -60,7 +64,6 @@ export default function ScheduleForm({
   const [scheduleError, setScheduleError] = useState("")
   const [nameError, setNameError] = useState("")
   const [gradeError, setGradeError] = useState("")
-  const [gradeOpts, setGradeOpts] = useState<string[]>(gradeOptions)
   const { eventId } = useParams()
 
   const tableRef = useRef<HTMLDivElement>(null)
@@ -69,10 +72,6 @@ export default function ScheduleForm({
     setSelectionMode(isMobile ? "tap" : "drag")
   }, [isMobile])
 
-  // イベント情報が読み込まれた際に選択肢を更新
-  useEffect(() => {
-    setGradeOpts(gradeOptions)
-  }, [gradeOptions])
 
   useEffect(() => {
     if (editingIndex !== null) {
@@ -138,6 +137,7 @@ export default function ScheduleForm({
       eventId,
       name: currentName,
       grade: currentGrade,
+      gradePriority: gradeOrder[currentGrade],
       schedule: currentSchedule,
     }
 
@@ -216,9 +216,9 @@ export default function ScheduleForm({
                   const newGrade = prompt("所属/役職を入力してください")
                   if (newGrade) {
                     const trimmed = newGrade.trim()
-                    if (trimmed && !gradeOpts.includes(trimmed)) {
-                      setGradeOpts([...gradeOpts, trimmed])
-                    }
+                    const pr = prompt("優先度を入力してください（数値）")
+                    const priority = pr ? Number(pr) : gradeOptions.length + 1
+                    addGradeOption(trimmed, priority)
                     setCurrentGrade(trimmed)
                   }
                   return
@@ -231,7 +231,7 @@ export default function ScheduleForm({
                 <SelectValue placeholder="所属/役職を選択" />
               </SelectTrigger>
               <SelectContent>
-                {gradeOpts.map((g) => (
+                {gradeOptions.map((g) => (
                   <SelectItem key={g} value={g}>
                     {g}
                   </SelectItem>

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -216,8 +216,26 @@ export default function ScheduleForm({
                   const newGrade = prompt("所属/役職を入力してください")
                   if (newGrade) {
                     const trimmed = newGrade.trim()
-                    const pr = prompt("優先度を入力してください（数値）")
-                    const priority = pr ? Number(pr) : gradeOptions.length + 1
+                    const existing = gradeOptions
+                      .map((g) => `${g}(${gradeOrder[g] ?? "-"})`)
+                      .join("\n")
+                    const pr = prompt(
+                      `優先度を入力してください（1〜999の半角数字。小さい数字ほど優先度が高く表示順が前になります）\n現在の設定:\n${existing}`
+                    )
+                    let priority: number
+                    if (!pr || pr.trim() === "") {
+                      const maxPri = Math.max(0, ...Object.values(gradeOrder))
+                      priority = maxPri + 1
+                    } else if (/^\d+$/.test(pr.trim())) {
+                      priority = Number(pr)
+                      if (priority < 1 || priority > 999) {
+                        alert("優先度は1〜999の半角数字で入力してください")
+                        return
+                      }
+                    } else {
+                      alert("優先度は1〜999の半角数字で入力してください")
+                      return
+                    }
                     addGradeOption(trimmed, priority)
                     setCurrentGrade(trimmed)
                   }
@@ -233,7 +251,7 @@ export default function ScheduleForm({
               <SelectContent>
                 {gradeOptions.map((g) => (
                   <SelectItem key={g} value={g}>
-                    {g}
+                    {g} (優先度: {gradeOrder[g]})
                   </SelectItem>
                 ))}
                 <SelectItem value="__add__">追加</SelectItem>

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label"
 import { MousePointer, Smartphone, Check } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
-import { gradeOptions, type ScheduleType } from "@/app/events/[eventId]/components/constants"
+import { type ScheduleType } from "@/app/events/[eventId]/components/constants"
 import type { Schedule, Participant } from "./types"
 import { createEmptySchedule } from "./utils"
 import { useMediaQuery } from "@/hooks/use-mobile"
@@ -21,6 +21,7 @@ type Props = {
   xAxis: string[]
   yAxis: string[]
   scheduleTypes: ScheduleType[]
+  gradeOptions: string[]
   currentName: string
   setCurrentName: Dispatch<SetStateAction<string>>
   currentGrade: string
@@ -38,6 +39,7 @@ export default function ScheduleForm({
   xAxis,
   yAxis,
   scheduleTypes,
+  gradeOptions,
   currentName,
   setCurrentName,
   currentGrade,
@@ -58,6 +60,7 @@ export default function ScheduleForm({
   const [scheduleError, setScheduleError] = useState("")
   const [nameError, setNameError] = useState("")
   const [gradeError, setGradeError] = useState("")
+  const [gradeOpts, setGradeOpts] = useState<string[]>(gradeOptions)
   const { eventId } = useParams()
 
   const tableRef = useRef<HTMLDivElement>(null)
@@ -65,6 +68,11 @@ export default function ScheduleForm({
   useEffect(() => {
     setSelectionMode(isMobile ? "tap" : "drag")
   }, [isMobile])
+
+  // イベント情報が読み込まれた際に選択肢を更新
+  useEffect(() => {
+    setGradeOpts(gradeOptions)
+  }, [gradeOptions])
 
   useEffect(() => {
     if (editingIndex !== null) {
@@ -109,7 +117,7 @@ export default function ScheduleForm({
     }
     setNameError("")
     if (!currentGrade) {
-      const message = "学年を選択してください"
+      const message = "所属/役職を選択してください"
       setGradeError(message)
       toast({ title: "エラー", description: message, variant: "destructive" })
       return
@@ -184,7 +192,7 @@ export default function ScheduleForm({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {/* 名前・学年入力 */}
+        {/* 名前・所属/役職入力 */}
         <div className="mb-4 grid grid-cols-2 gap-4">
           <div>
             <Label htmlFor="name">名前</Label>
@@ -200,23 +208,35 @@ export default function ScheduleForm({
             {nameError && <p className="mt-2 text-sm text-red-500">{nameError}</p>}
           </div>
           <div>
-            <Label htmlFor="grade-select">学年</Label>
+            <Label htmlFor="grade-select">所属/役職</Label>
             <Select
               value={currentGrade}
               onValueChange={(v) => {
+                if (v === "__add__") {
+                  const newGrade = prompt("所属/役職を入力してください")
+                  if (newGrade) {
+                    const trimmed = newGrade.trim()
+                    if (trimmed && !gradeOpts.includes(trimmed)) {
+                      setGradeOpts([...gradeOpts, trimmed])
+                    }
+                    setCurrentGrade(trimmed)
+                  }
+                  return
+                }
                 setCurrentGrade(v)
                 setGradeError("")
               }}
             >
               <SelectTrigger id="grade-select" className="w-full">
-                <SelectValue placeholder="学年を選択" />
+                <SelectValue placeholder="所属/役職を選択" />
               </SelectTrigger>
               <SelectContent>
-                {gradeOptions.map((g) => (
+                {gradeOpts.map((g) => (
                   <SelectItem key={g} value={g}>
                     {g}
                   </SelectItem>
                 ))}
+                <SelectItem value="__add__">追加</SelectItem>
               </SelectContent>
             </Select>
             {gradeError && <p className="mt-2 text-sm text-red-500">{gradeError}</p>}

--- a/app/events/[eventId]/components/SchedulePage.tsx
+++ b/app/events/[eventId]/components/SchedulePage.tsx
@@ -26,15 +26,16 @@ import BestTimeSlots from './BestTimeSlots'
 import { createEmptySchedule } from './utils'
 import type { Participant, Schedule } from './types'
 import { useParams } from 'next/navigation'
-import { gradeOptions, ScheduleType } from './constants'
+import { ScheduleType } from './constants'
 
 type Props = {
   xAxis: string[]
   yAxis: string[]
   scheduleTypes: ScheduleType[]
+  gradeOptions: string[]
 }
 
-export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
+export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions }: Props) {
   const defaultTypeId = scheduleTypes.find((t) => t.isAvailable)?.id || ''
   const [participants, setParticipants] = useState<Participant[]>([])
   const [availableOptions, setAvailableOptions] = useState<string[]>([])
@@ -122,7 +123,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
     link.remove()
   }
 
-  // 学年フィルタリング
+  // 所属/役職フィルタリング
   const filteredParticipants =
     filterGrades.length === 0
       ? participants
@@ -194,6 +195,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
             editingIndex={editingIndex}
             setEditingIndex={setEditingIndex}
             setActiveTab={setActiveTab}
+            gradeOptions={gradeOptions}
           />
         </TabsContent>
 
@@ -209,13 +211,14 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
             xAxis={xAxis}
             yAxis={yAxis}
             availableOptions={availableOptions}
+            gradeOptions={gradeOptions}
           />
         </TabsContent>
 
         <TabsContent value="summary">
            <div className="mb-4 p-4 bg-gray-50 rounded-lg border">
         <div className="flex items-center justify-between mb-3">
-          <Label className="text-sm font-medium">学年で絞り込み</Label>
+          <Label className="text-sm font-medium">所属/役職で絞り込み</Label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={() => setFilterGrades(gradeOptions)} className="text-xs">
               全選択
@@ -263,7 +266,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
 
         {filterGrades.length > 0 && (
           <div className="mt-3 text-sm text-gray-600">
-            {filterGrades.length}個の学年を選択中 ({filteredParticipants.length}名が対象)
+            {filterGrades.length}個の所属/役職を選択中 ({filteredParticipants.length}名が対象)
           </div>
         )}
       </div>
@@ -284,7 +287,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes }: Props) {
           </div>
 
           <div className="mt-12">
-            <h3 className="text-xl font-semibold mb-4">学年別集計（全体表示）</h3>
+            <h3 className="text-xl font-semibold mb-4">所属/役職別集計（全体表示）</h3>
             <div className="space-y-8">
               {gradeOptions.map((g) => {
                 const group = participants.filter((p) => p.grade === g)

--- a/app/events/[eventId]/components/constants.ts
+++ b/app/events/[eventId]/components/constants.ts
@@ -25,6 +25,7 @@ export type EventData = {
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
+  gradeOptions: string[]
 }
 
 // スケジュールの種類と対応する表示色など
@@ -41,7 +42,9 @@ export const scheduleTypes = [
 // 曜日と時限の定義
 export const days = ["月", "火", "水", "木", "金"]
 export const periods = [1, 2, 3, 4, 5]
-export const gradeOptions = [
+
+// 所属/役職のデフォルト値
+export const defaultGradeOptions = [
   'Teacher',
   'Dr',
   'M2',
@@ -53,7 +56,7 @@ export const gradeOptions = [
   'Others',
 ]
 
-export const gradeOrder: { [key: string]: number } = {
+export const defaultGradeOrder: { [key: string]: number } = {
   Teacher: 1,
   Dr: 2,
   M2: 3,

--- a/app/events/[eventId]/components/constants.ts
+++ b/app/events/[eventId]/components/constants.ts
@@ -26,6 +26,7 @@ export type EventData = {
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
   gradeOptions: string[]
+  gradeOrder: { [key: string]: number }
 }
 
 // スケジュールの種類と対応する表示色など

--- a/app/events/[eventId]/components/useParticipantForm.tsx
+++ b/app/events/[eventId]/components/useParticipantForm.tsx
@@ -10,6 +10,7 @@ export function useParticipantForm(
   responses: Response[],
   setActiveTab: (tab: string) => void,
   gradeOptions: string[],
+  gradeOrder: Record<string, number>,
 ) {
   const [name, setName] = useState<string>("")
   const [grade, setGrade] = useState<string>("")
@@ -106,7 +107,7 @@ export function useParticipantForm(
     }
     setIsSubmitting(true)
     try {
-      const responseData = { eventId, name, grade,
+      const responseData = { eventId, name, grade, gradePriority: gradeOrderMap[grade],
         schedule: Object.entries(selections).map(([dateTime, typeId]) => ({ dateTime, typeId, comment: comments[dateTime] || "" }))
       }
       const response = await fetch(`/api/events/${eventId}/participants`, {
@@ -134,7 +135,7 @@ export function useParticipantForm(
     setIsEditing(true)
     try {
       const responseData = {
-        name: editName, grade: editGrade,
+        name: editName, grade: editGrade, gradePriority: gradeOrderMap[editGrade],
         schedule: Object.entries(editSelections).map(([dateTime, typeId]) => ({ dateTime, typeId, comment: editComments[dateTime] || "" }))
       }
       const response = await fetch(`/api/events/${eventId}/participants/${editingResponse.id}`, {
@@ -200,8 +201,8 @@ export function useParticipantForm(
   }
 
   const gradeOrderMap = useMemo(() => {
-    return gradeOptions.reduce((acc, g, i) => ({ ...acc, [g]: i }), {} as Record<string, number>)
-  }, [gradeOptions])
+    return gradeOrder
+  }, [gradeOrder])
 
   const getSortedResponses = () => {
     if (!existingResponses.length) return []

--- a/app/events/[eventId]/components/useParticipantForm.tsx
+++ b/app/events/[eventId]/components/useParticipantForm.tsx
@@ -43,6 +43,11 @@ export function useParticipantForm(
     if (c) setComments(JSON.parse(c))
   }, [eventId])
 
+  // sync external responses when parent data changes
+  useEffect(() => {
+    setExistingResponses(Array.isArray(responses) ? responses : [])
+  }, [responses])
+
   // 回答者の参加可能日数を取得
   const getAvailableDatesCount = (response: Response) => {
     return response.schedule.filter((selection) => {


### PR DESCRIPTION
## Summary
- replace fixed "学年" field with customizable "所属/役職" options
- allow event creators and participants to add affiliation choices
- persist new affiliations and include them in analytics
- fix schedule and one-time forms to load event's affiliation options instead of only showing "追加"
- fix error when creating events by forwarding affiliation options to the schedule form

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c93e0ee88328bdab1c2ba159968a