### PR TITLE
feat: add share button to event pages

### DIFF
--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -202,6 +202,24 @@ export default function EventPage() {
 
   const shareEvent = () => {
     const url = window.location.href
+
+    navigator.clipboard.writeText(url).then(
+      () => {
+        toast({
+          title: "URLをコピーしました",
+          description: "イベントのURLがクリップボードにコピーされました。",
+        })
+      },
+      (err) => {
+        console.error("URLのコピーに失敗しました:", err)
+        toast({
+          title: "コピーに失敗しました",
+          description: "URLのコピーに失敗しました。もう一度お試しください。",
+          variant: "destructive",
+        })
+      },
+    )
+
     if (navigator.share) {
       navigator
         .share({
@@ -217,23 +235,6 @@ export default function EventPage() {
             variant: "destructive",
           })
         })
-    } else {
-      navigator.clipboard.writeText(url).then(
-        () => {
-          toast({
-            title: "URLをコピーしました",
-            description: "イベントのURLがクリップボードにコピーされました。",
-          })
-        },
-        (err) => {
-          console.error("URLのコピーに失敗しました:", err)
-          toast({
-            title: "コピーに失敗しました",
-            description: "URLのコピーに失敗しました。もう一度お試しください。",
-            variant: "destructive",
-          })
-        },
-      )
     }
   }
 

--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { toast } from "@/components/ui/use-toast"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Plus, Trash2, Save, X, BarChart3 } from "lucide-react"
+import { Plus, Trash2, Save, X, BarChart3, Share2 } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import SchedulePage from "@/app/events/[eventId]/components/SchedulePage"
@@ -198,6 +198,43 @@ export default function EventPage() {
     const newOptions = [...editDateTimeOptions]
     newOptions[index] = value
     setEditDateTimeOptions(newOptions)
+  }
+
+  const shareEvent = () => {
+    const url = window.location.href
+    if (navigator.share) {
+      navigator
+        .share({
+          title: data.name,
+          text: data.description,
+          url,
+        })
+        .catch((err) => {
+          console.error("URLの共有に失敗しました:", err)
+          toast({
+            title: "共有に失敗しました",
+            description: "URLの共有に失敗しました。もう一度お試しください。",
+            variant: "destructive",
+          })
+        })
+    } else {
+      navigator.clipboard.writeText(url).then(
+        () => {
+          toast({
+            title: "URLをコピーしました",
+            description: "イベントのURLがクリップボードにコピーされました。",
+          })
+        },
+        (err) => {
+          console.error("URLのコピーに失敗しました:", err)
+          toast({
+            title: "コピーに失敗しました",
+            description: "URLのコピーに失敗しました。もう一度お試しください。",
+            variant: "destructive",
+          })
+        },
+      )
+    }
   }
 
   // 予定タイプを追加
@@ -823,6 +860,10 @@ export default function EventPage() {
           <h1 className="text-2xl md:text-3xl font-bold">{data.name}</h1>
           <p className="text-gray-700">{data.description}</p>
           <div className="flex gap-2">
+            <Button variant="outline" onClick={shareEvent}>
+              <Share2 className="h-4 w-4 mr-2" />
+              共有
+            </Button>
             <Button variant="outline" onClick={() => setEditMode(true)}>
               編集
             </Button>

--- a/app/events/[eventId]/components/EventHeader.tsx
+++ b/app/events/[eventId]/components/EventHeader.tsx
@@ -38,6 +38,24 @@ export default function EventHeader({
   // イベントを共有
   const shareEvent = () => {
     const url = window.location.href
+
+    navigator.clipboard.writeText(url).then(
+      () => {
+        toast({
+          title: "URLをコピーしました",
+          description: "イベントのURLがクリップボードにコピーされました。",
+        })
+      },
+      (err) => {
+        console.error("URLのコピーに失敗しました:", err)
+        toast({
+          title: "コピーに失敗しました",
+          description: "URLのコピーに失敗しました。もう一度お試しください。",
+          variant: "destructive",
+        })
+      },
+    )
+
     if (navigator.share) {
       navigator
         .share({
@@ -53,23 +71,6 @@ export default function EventHeader({
             variant: "destructive",
           })
         })
-    } else {
-      navigator.clipboard.writeText(url).then(
-        () => {
-          toast({
-            title: "URLをコピーしました",
-            description: "イベントのURLがクリップボードにコピーされました。",
-          })
-        },
-        (err) => {
-          console.error("URLのコピーに失敗しました:", err)
-          toast({
-            title: "コピーに失敗しました",
-            description: "URLのコピーに失敗しました。もう一度お試しください。",
-            variant: "destructive",
-          })
-        },
-      )
     }
   }
 

--- a/app/events/[eventId]/components/EventHeader.tsx
+++ b/app/events/[eventId]/components/EventHeader.tsx
@@ -35,25 +35,42 @@ export default function EventHeader({
 }: EventHeaderProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
-  // イベントURLをコピー
-  const copyEventUrl = () => {
+  // イベントを共有
+  const shareEvent = () => {
     const url = window.location.href
-    navigator.clipboard.writeText(url).then(
-      () => {
-        toast({
-          title: "URLをコピーしました",
-          description: "イベントのURLがクリップボードにコピーされました。",
+    if (navigator.share) {
+      navigator
+        .share({
+          title: eventName,
+          text: eventDescription,
+          url,
         })
-      },
-      (err) => {
-        console.error("URLのコピーに失敗しました:", err)
-        toast({
-          title: "コピーに失敗しました",
-          description: "URLのコピーに失敗しました。もう一度お試しください。",
-          variant: "destructive",
+        .catch((err) => {
+          console.error("URLの共有に失敗しました:", err)
+          toast({
+            title: "共有に失敗しました",
+            description: "URLの共有に失敗しました。もう一度お試しください。",
+            variant: "destructive",
+          })
         })
-      },
-    )
+    } else {
+      navigator.clipboard.writeText(url).then(
+        () => {
+          toast({
+            title: "URLをコピーしました",
+            description: "イベントのURLがクリップボードにコピーされました。",
+          })
+        },
+        (err) => {
+          console.error("URLのコピーに失敗しました:", err)
+          toast({
+            title: "コピーに失敗しました",
+            description: "URLのコピーに失敗しました。もう一度お試しください。",
+            variant: "destructive",
+          })
+        },
+      )
+    }
   }
 
   return (
@@ -79,7 +96,7 @@ export default function EventHeader({
           </div>
 
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={copyEventUrl}>
+            <Button variant="outline" size="sm" onClick={shareEvent}>
               <Share2 className="h-4 w-4 mr-1" />
               共有
             </Button>


### PR DESCRIPTION
## Summary
- enable Web Share API on event page with clipboard fallback
- add share button to event header for easy link sharing

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b4192cffa08328980dbe497051b9ac