### PR TITLE
Add scheduled cleanup for old events

### DIFF
--- a/app/api/cron/delete-old-events/route.ts
+++ b/app/api/cron/delete-old-events/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/firebase"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const cutoff = new Date()
+    cutoff.setMonth(cutoff.getMonth() - 3)
+
+    const snapshot = await db
+      .collection("events")
+      .where("createdAt", "<", cutoff)
+      .get()
+
+    const batch = db.batch()
+    snapshot.docs.forEach((doc) => batch.delete(doc.ref))
+    await batch.commit()
+
+    return NextResponse.json({ deleted: snapshot.size })
+  } catch (err) {
+    console.error("Failed to delete old events", err)
+    return NextResponse.json(
+      { error: "Failed to delete old events" },
+      { status: 500 }
+    )
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/delete-old-events",
+      "schedule": "0 0 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add API route that deletes events older than three months
- configure Vercel cron to run daily cleanup

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint? command failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b42fe59f848328a24b76620601b601