### PR TITLE
Add privacy policy pages and footer link

### DIFF
--- a/app/en/privacy/page.tsx
+++ b/app/en/privacy/page.tsx
@@ -1,0 +1,14 @@
+export default function PrivacyPage() {
+  return (
+    <main className="container mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
+      <p className="mb-2">
+        Data submitted through this service is not encrypted. Do not submit sensitive or confidential information.
+      </p>
+      <p className="mb-2">
+        We are not responsible for any damages resulting from the use of this service.
+      </p>
+      <p className="mb-2">Use the service at your own risk.</p>
+    </main>
+  )
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,12 @@
+export default function PrivacyPage() {
+  return (
+    <main className="container mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-4">プライバシーポリシー</h1>
+      <p className="mb-2">
+        本サービスでは、送信されたデータは暗号化されておらず、機密情報の入力は行わないでください。
+      </p>
+      <p className="mb-2">利用により生じた損害について、当方は一切責任を負いません。</p>
+      <p className="mb-2">ご利用は自己責任でお願いします。</p>
+    </main>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,3 +1,21 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
 export default function Footer() {
-  return <footer className="text-center p-4">© dekopon21020014</footer>
+  const pathname = usePathname()
+  const isEnglish = pathname.startsWith("/en")
+  const prefix = isEnglish ? "/en" : ""
+  const label = isEnglish ? "Privacy Policy" : "プライバシーポリシー"
+
+  return (
+    <footer className="text-center p-4">
+      © dekopon21020014
+      <span className="mx-2">|</span>
+      <Link href={`${prefix}/privacy`} className="underline">
+        {label}
+      </Link>
+    </footer>
+  )
 }


### PR DESCRIPTION
## Summary
- add privacy policy pages in Japanese and English
- link privacy policy from footer with locale detection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fdb1faa883289992a9e089b97720