### PR TITLE
Add About page with repository link

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,23 @@
+export default function AboutPage() {
+  return (
+    <main className="container mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-4">このサイトについて</h1>
+      <p className="mb-2">
+        Lab Schedulingは研究室のイベントやミーティングの日程調整を支援するためのオープンソースプロジェクトです。
+      </p>
+      <p className="mb-2">
+        ソースコードはGitHubで公開されており、改善の提案やバグ報告を歓迎しています。
+      </p>
+      <p>
+        <a
+          href="https://github.com/dekopon21020014/lab-scheduling"
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          https://github.com/dekopon21020014/lab-scheduling
+        </a>
+      </p>
+    </main>
+  )
+}

--- a/app/en/about/page.tsx
+++ b/app/en/about/page.tsx
@@ -1,0 +1,23 @@
+export default function AboutPage() {
+  return (
+    <main className="container mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-4">About</h1>
+      <p className="mb-2">
+        Lab Scheduling is an open-source project designed to help research groups coordinate events and meetings.
+      </p>
+      <p className="mb-2">
+        The source code is available on GitHub, and contributions via issues or pull requests are welcome.
+      </p>
+      <p>
+        <a
+          href="https://github.com/dekopon21020014/lab-scheduling"
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          https://github.com/dekopon21020014/lab-scheduling
+        </a>
+      </p>
+    </main>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -7,14 +7,19 @@ export default function Footer() {
   const pathname = usePathname()
   const isEnglish = pathname.startsWith("/en")
   const prefix = isEnglish ? "/en" : ""
-  const label = isEnglish ? "Privacy Policy" : "プライバシーポリシー"
+  const privacyLabel = isEnglish ? "Privacy Policy" : "プライバシーポリシー"
+  const aboutLabel = isEnglish ? "About" : "このサイトについて"
 
   return (
     <footer className="text-center p-4">
       © dekopon21020014
       <span className="mx-2">|</span>
       <Link href={`${prefix}/privacy`} className="underline">
-        {label}
+        {privacyLabel}
+      </Link>
+      <span className="mx-2">|</span>
+      <Link href={`${prefix}/about`} className="underline">
+        {aboutLabel}
       </Link>
     </footer>
   )

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -10,6 +10,7 @@ export default function Header() {
   const navItems = [
     { href: prefix || "/", label: "Home" },
     { href: `${prefix}/builder`, label: "Builder" },
+    { href: `${prefix}/about`, label: "About" },
   ]
   const langHref = isEnglish
     ? pathname.replace(/^\/en/, "") || "/"


### PR DESCRIPTION
## Summary
- add Japanese and English about pages with repository URL
- link About page from header and footer

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test` *(fails: vitest exited while waiting for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_68b571d7e8a88328afaa16a1cddbe3f3