### PR TITLE
Improve clarity of event type selection

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -449,6 +449,9 @@ export default function HomePage() {
               </CardTitle>
             </CardHeader>
             <CardContent>
+              <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                イベントの形式を選択してください。
+              </p>
               <ToggleGroup
                 type="single"
                 value={eventType}
@@ -458,7 +461,7 @@ export default function HomePage() {
                 <ToggleGroupItem
                   value="recurring"
                   aria-label="定期イベント"
-                  className="w-full data-[state=on]:bg-black data-[state=on]:text-white"
+                  className="w-full cursor-pointer rounded-md border py-2 data-[state=on]:bg-black data-[state=on]:text-white"
                 >
                   <CalendarDays className="mr-2 h-4 w-4" />
                   定期イベント
@@ -466,7 +469,7 @@ export default function HomePage() {
                 <ToggleGroupItem
                   value="onetime"
                   aria-label="単発イベント"
-                  className="w-full data-[state=on]:bg-black data-[state=on]:text-white"
+                  className="w-full cursor-pointer rounded-md border py-2 data-[state=on]:bg-black data-[state=on]:text-white"
                 >
                   <Calendar className="mr-2 h-4 w-4" />
                   単発イベント

--- a/app/en/builder/page.tsx
+++ b/app/en/builder/page.tsx
@@ -460,6 +460,9 @@ export default function HomePage() {
               </CardTitle>
             </CardHeader>
             <CardContent>
+              <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                Please select the event type.
+              </p>
               <ToggleGroup
                 type="single"
                 value={eventType}
@@ -469,7 +472,7 @@ export default function HomePage() {
                 <ToggleGroupItem
                   value="recurring"
                   aria-label="Recurring Event"
-                  className="w-full data-[state=on]:bg-black data-[state=on]:text-white"
+                  className="w-full cursor-pointer rounded-md border py-2 data-[state=on]:bg-black data-[state=on]:text-white"
                 >
                   <CalendarDays className="mr-2 h-4 w-4" />
                   Recurring Event
@@ -477,7 +480,7 @@ export default function HomePage() {
                 <ToggleGroupItem
                   value="onetime"
                   aria-label="One-time Event"
-                  className="w-full data-[state=on]:bg-black data-[state=on]:text-white"
+                  className="w-full cursor-pointer rounded-md border py-2 data-[state=on]:bg-black data-[state=on]:text-white"
                 >
                   <Calendar className="mr-2 h-4 w-4" />
                   One-time Event


### PR DESCRIPTION
## Summary
- Add hint text and styling so event type toggle buttons look like actionable choices
- Make it clearer that either recurring or one-time event must be selected

## Testing
- `yarn test`
- `yarn lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b58a8e5710832882ad4797237aea7c