### PR TITLE
feat: add event type selection step

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -47,7 +47,7 @@ export default function HomePage() {
   const [eventDesc, setEventDesc] = useState("")
   const [usePassword, setUsePassword] = useState(false)
   const [eventPassword, setEventPassword] = useState("")
-  const [eventType, setEventType] = useState<"recurring" | "onetime">("recurring")
+  const [eventType, setEventType] = useState<"recurring" | "onetime" | undefined>(undefined)
 
   // 定期イベント用の軸
   const [xAxis, setXAxis] = useState(xAxisTemplate)
@@ -278,6 +278,11 @@ export default function HomePage() {
       return
     }
 
+    if (!eventType) {
+      toast({ title: "エラー", description: "イベントタイプを選択してください", variant: "destructive" })
+      return
+    }
+
     // イベントタイプに応じたバリデーション
     if (eventType === "recurring") {
       if (xAxis.length === 0 || yAxis.length === 0) {
@@ -455,7 +460,9 @@ export default function HomePage() {
               <ToggleGroup
                 type="single"
                 value={eventType}
-                onValueChange={(value) => setEventType(value as "recurring" | "onetime")}
+                onValueChange={(value) =>
+                  setEventType(value ? (value as "recurring" | "onetime") : undefined)
+                }
                 className="grid w-full grid-cols-2 gap-2"
               >
                 <ToggleGroupItem
@@ -479,7 +486,9 @@ export default function HomePage() {
               <div className="mt-2 text-sm text-gray-600 dark:text-gray-400">
                 {eventType === "recurring"
                   ? "定期的なミーティングや授業など、曜日×時間のグリッド形式で調整します。"
-                  : "単発のイベントや会議など、特定の日時のリストから選択して調整します。"}
+                  : eventType === "onetime"
+                    ? "単発のイベントや会議など、特定の日時のリストから選択して調整します。"
+                    : null}
               </div>
             </CardContent>
           </Card>
@@ -560,15 +569,20 @@ export default function HomePage() {
           </Card>
         </div>
 
-        <Card className="bg-white dark:bg-gray-800 shadow-sm border">
-          <CardHeader className="pb-4">
-            <CardTitle className="text-lg font-medium flex items-center gap-2">
-              {eventType === "recurring" ? <CalendarDays className="h-5 w-5" /> : <Clock className="h-5 w-5" />}
-              {eventType === "recurring" ? "グリッド設定" : "日時設定"}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        {eventType && (
+          <Card className="bg-white dark:bg-gray-800 shadow-sm border">
+            <CardHeader className="pb-4">
+              <CardTitle className="text-lg font-medium flex items-center gap-2">
+                {eventType === "recurring" ? (
+                  <CalendarDays className="h-5 w-5" />
+                ) : (
+                  <Clock className="h-5 w-5" />
+                )}
+                {eventType === "recurring" ? "グリッド設定" : "日時設定"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
               <TabsList className="mb-4 flex w-full overflow-x-auto justify-start md:justify-center bg-white/60 dark:bg-gray-700/50 p-1 rounded-lg">
                 <TabsTrigger value="builder">
                   {eventType === "recurring" ? "グリッドビルダー" : "日時リスト"}
@@ -1008,9 +1022,10 @@ export default function HomePage() {
                   </div>
                 )}
               </TabsContent>
-            </Tabs>
-          </CardContent>
-        </Card>
+              </Tabs>
+            </CardContent>
+          </Card>
+        )}
 
         <div className="flex justify-center pt-4">
           <Button type="submit" size="lg" className="px-8">

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -460,9 +460,10 @@ export default function HomePage() {
               <ToggleGroup
                 type="single"
                 value={eventType}
-                onValueChange={(value) =>
-                  setEventType(value ? (value as "recurring" | "onetime") : undefined)
-                }
+                onValueChange={(value) => {
+                  if (!value) return
+                  setEventType(value as "recurring" | "onetime")
+                }}
                 className="grid w-full grid-cols-2 gap-2"
               >
                 <ToggleGroupItem
@@ -1027,12 +1028,14 @@ export default function HomePage() {
           </Card>
         )}
 
-        <div className="flex justify-center pt-4">
-          <Button type="submit" size="lg" className="px-8">
-            <Save className="h-4 w-4 mr-2" />
-            イベントを作成
-          </Button>
-        </div>
+        {eventType && (
+          <div className="flex justify-center pt-4">
+            <Button type="submit" size="lg" className="px-8">
+              <Save className="h-4 w-4 mr-2" />
+              イベントを作成
+            </Button>
+          </div>
+        )}
       </form>
     </div>
   )

--- a/app/en/builder/page.tsx
+++ b/app/en/builder/page.tsx
@@ -47,7 +47,7 @@ export default function HomePage() {
   const [eventDesc, setEventDesc] = useState("")
   const [usePassword, setUsePassword] = useState(false)
   const [eventPassword, setEventPassword] = useState("")
-  const [eventType, setEventType] = useState<"recurring" | "onetime">("recurring")
+  const [eventType, setEventType] = useState<"recurring" | "onetime" | undefined>(undefined)
 
   // Axes for recurring events
   const [xAxis, setXAxis] = useState(xAxisTemplate)
@@ -283,6 +283,11 @@ export default function HomePage() {
       return
     }
 
+    if (!eventType) {
+      toast({ title: "Error", description: "Please select the event type", variant: "destructive" })
+      return
+    }
+
     // Validation based on event type
     if (eventType === "recurring") {
       if (xAxis.length === 0 || yAxis.length === 0) {
@@ -466,7 +471,9 @@ export default function HomePage() {
               <ToggleGroup
                 type="single"
                 value={eventType}
-                onValueChange={(value) => setEventType(value as "recurring" | "onetime")}
+                onValueChange={(value) =>
+                  setEventType(value ? (value as "recurring" | "onetime") : undefined)
+                }
                 className="grid w-full grid-cols-2 gap-2"
               >
                 <ToggleGroupItem
@@ -490,7 +497,9 @@ export default function HomePage() {
               <div className="mt-2 text-sm text-gray-600 dark:text-gray-400">
                 {eventType === "recurring"
                   ? "For recurring meetings or classes, schedule using a day × time grid."
-                  : "For one-off events or meetings, choose from a list of specific date-times."}
+                  : eventType === "onetime"
+                    ? "For one-off events or meetings, choose from a list of specific date-times."
+                    : null}
               </div>
             </CardContent>
           </Card>
@@ -569,19 +578,20 @@ export default function HomePage() {
         </Card>
         </div>
 
-        <Card className="bg-white dark:bg-gray-800 shadow-sm border">
-          <CardHeader className="pb-4">
-            <CardTitle className="text-lg font-medium flex items-center gap-2">
-              {eventType === "recurring" ? (
-                <CalendarDays className="h-5 w-5" />
-              ) : (
-                <Clock className="h-5 w-5" />
-              )}
-              {eventType === "recurring" ? "Grid Settings" : "Date-Time Settings"}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        {eventType && (
+          <Card className="bg-white dark:bg-gray-800 shadow-sm border">
+            <CardHeader className="pb-4">
+              <CardTitle className="text-lg font-medium flex items-center gap-2">
+                {eventType === "recurring" ? (
+                  <CalendarDays className="h-5 w-5" />
+                ) : (
+                  <Clock className="h-5 w-5" />
+                )}
+                {eventType === "recurring" ? "Grid Settings" : "Date-Time Settings"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
               <TabsList className="mb-4 flex w-full overflow-x-auto justify-start md:justify-center bg-white/60 dark:bg-gray-700/50 p-1 rounded-lg">
             <TabsTrigger value="builder">{eventType === "recurring" ? "Grid Builder" : "Date-Time List"}</TabsTrigger>
             <TabsTrigger value="scheduleTypes">Schedule Types</TabsTrigger>
@@ -1019,9 +1029,10 @@ export default function HomePage() {
                 </div>
               )}
             </TabsContent>
-          </Tabs>
-          </CardContent>
-        </Card>
+              </Tabs>
+            </CardContent>
+          </Card>
+        )}
 
         <div className="flex justify-center pt-4">
           <Button type="submit" size="lg" className="px-8">

--- a/app/en/builder/page.tsx
+++ b/app/en/builder/page.tsx
@@ -471,9 +471,10 @@ export default function HomePage() {
               <ToggleGroup
                 type="single"
                 value={eventType}
-                onValueChange={(value) =>
-                  setEventType(value ? (value as "recurring" | "onetime") : undefined)
-                }
+                onValueChange={(value) => {
+                  if (!value) return
+                  setEventType(value as "recurring" | "onetime")
+                }}
                 className="grid w-full grid-cols-2 gap-2"
               >
                 <ToggleGroupItem
@@ -1034,12 +1035,14 @@ export default function HomePage() {
           </Card>
         )}
 
-        <div className="flex justify-center pt-4">
-          <Button type="submit" size="lg" className="px-8">
-            <Save className="h-4 w-4 mr-2" />
-            Create Event
-          </Button>
-        </div>
+        {eventType && (
+          <div className="flex justify-center pt-4">
+            <Button type="submit" size="lg" className="px-8">
+              <Save className="h-4 w-4 mr-2" />
+              Create Event
+            </Button>
+          </div>
+        )}
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- start builder pages with no event type selected
- require event type before submitting event data
- show grid/date-time configuration only after selecting an event type

## Testing
- `pnpm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68b5994dc3208328a3b716bee4555e1a