### PR TITLE
Add 3-month deletion notice to builder pages

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -381,6 +381,10 @@ export default function HomePage() {
         </div>
       </div>
 
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        作成から3ヶ月後にページは自動的に削除されます。
+      </p>
+
       <form onSubmit={handleSubmit} className="max-w-7xl mx-auto space-y-6">
         <div className="grid lg:grid-cols-3 md:grid-cols-2 gap-4">
           <Card className="bg-white dark:bg-gray-800 border shadow-sm">

--- a/app/en/builder/page.tsx
+++ b/app/en/builder/page.tsx
@@ -388,6 +388,10 @@ export default function HomePage() {
         </div>
       </div>
 
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Event pages are automatically deleted 3 months after creation.
+      </p>
+
       <form onSubmit={handleSubmit} className="max-w-7xl mx-auto space-y-6">
         <div className="grid lg:grid-cols-3 md:grid-cols-2 gap-4">
           <Card className="bg-white dark:bg-gray-800 border shadow-sm">


### PR DESCRIPTION
## Summary
- Explain on Japanese builder page that pages are automatically deleted 3 months after creation.
- Add the same 3-month deletion notice to the English builder page.

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b5b9c335a483289c367b3084333eb9