### PR TITLE
Rename app to Atsumalo

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-# Lab Scheduling
+# Atsumalo
 
 An online scheduling tool that centralizes management of laboratory equipment and room usage.
 Members can check availability on a shared calendar and easily reserve time for experiments or meetings.

--- a/app/en/layout.tsx
+++ b/app/en/layout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react"
 
 export const metadata = {
-  title: "Lab Scheduling",
+  title: "Atsumalo",
   description: "An application to coordinate schedules for research labs.",
 }
 

--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -8,7 +8,7 @@ export default function LandingPage() {
     <main className="flex flex-col">
       <section className="relative isolate overflow-hidden bg-black text-white py-32">
         <div className="container mx-auto text-center">
-          <h1 className="text-5xl font-bold tracking-tight mb-6">Lab Scheduling</h1>
+          <h1 className="text-5xl font-bold tracking-tight mb-6">Atsumalo</h1>
           <p className="text-xl max-w-2xl mx-auto mb-8">
             Simplify and streamline the scheduling of lab events and meetings.
           </p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,9 +7,9 @@ import Footer from "@/components/footer"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata = {
-  title: "日程調整アプリ",
+  title: "あつま郎",
   description: "大学の研究室などで日程を調整するためのアプリケーション",
-    generator: 'v0.dev'
+  generator: "v0.dev",
 }
 
 export default function RootLayout({ children }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default function LandingPage() {
     <main className="flex flex-col">
       <section className="relative isolate overflow-hidden bg-black text-white py-32">
         <div className="container mx-auto text-center">
-          <h1 className="text-5xl font-bold tracking-tight mb-6">Lab Scheduling</h1>
+          <h1 className="text-5xl font-bold tracking-tight mb-6">あつま郎</h1>
           <p className="text-xl max-w-2xl mx-auto mb-8">
             研究室のイベントやミーティングの日程調整をもっとシンプルに、スマートに。
           </p>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,6 +7,7 @@ export default function Header() {
   const pathname = usePathname()
   const isEnglish = pathname.startsWith("/en")
   const prefix = isEnglish ? "/en" : ""
+  const appName = isEnglish ? "Atsumalo" : "あつま郎"
   const navItems = [
     { href: prefix || "/", label: "Home" },
     { href: `${prefix}/builder`, label: "Builder" },
@@ -20,7 +21,7 @@ export default function Header() {
     <header className="bg-gray-100 dark:bg-gray-900 p-4">
       <div className="container mx-auto flex items-center justify-between">
         <h1 className="text-xl font-bold">
-          <Link href={prefix || "/"}>Lab Scheduling</Link>
+          <Link href={prefix || "/"}>{appName}</Link>
         </h1>
         <nav className="space-x-4">
           {navItems.map((item) => (


### PR DESCRIPTION
## Summary
- rename app branding to Atsumalo/あつま郎 across pages and header
- update site metadata and English README

## Testing
- `yarn lint` *(fails: How would you like to configure ESLint?)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b64f0c99d483289ecd7b0b1692f902