### PR TITLE
feat: allow editing schedule from grid

### DIFF
--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -236,10 +236,13 @@ export default function ParticipantList({
               </tr>
             </thead>
             <tbody>
-              {displayed.map((part) => (
+              {displayed.map((part, idx) => (
                 <tr key={part.id}>
-                  <td className="border p-1 font-medium sticky left-0 bg-white z-10">
-                  {part.grade}: {part.name}
+                  <td
+                    className="border p-1 font-medium sticky left-0 bg-white z-10 cursor-pointer hover:bg-gray-100"
+                    onClick={() => handleEdit(idx)}
+                  >
+                    {part.grade}: {part.name}
                   </td>
                   {xAxis.map((day) =>
                     yAxis.map((period) => {


### PR DESCRIPTION
## Summary
- enable editing schedule when clicking participant name in grid view

## Testing
- `pnpm test -- --run`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b9946ca894832898b8aeca9eb78f2d